### PR TITLE
[FEAT#2] 완료한/참여중 커뮤니티 조회 api 통합

### DIFF
--- a/be/functions/src/routes/users.js
+++ b/be/functions/src/routes/users.js
@@ -780,7 +780,7 @@ router.get("/me/commented-posts", authGuard, userController.getMyCommentedPosts)
  * /users/me/participating-communities:
  *   get:
  *     summary: 내가 참여 중인 커뮤니티 조회
- *     description: 로그인한 사용자가 참여 중인 커뮤니티를 조회합니다.
+ *     description: 로그인한 사용자가 참여 중인 커뮤니티(진행 중 + 완료된 커뮤니티 모두 포함)를 조회합니다.
  *     tags: [Users]
  *     security:
  *       - bearerAuth: []
@@ -823,6 +823,11 @@ router.get("/me/commented-posts", authGuard, userController.getMyCommentedPosts)
  *                                 type: string
  *                                 description: 신청 상태
  *                                 example: "approved"
+ *                               programStatus:
+ *                                 type: string
+ *                                 enum: [ongoing, completed]
+ *                                 description: 프로그램 상태 (ongoing=진행중, completed=종료)
+ *                                 example: "ongoing"
  *                     gathering:
  *                       type: object
  *                       description: 월간 소모임 그룹
@@ -848,6 +853,11 @@ router.get("/me/commented-posts", authGuard, userController.getMyCommentedPosts)
  *                                 type: string
  *                                 description: 신청 상태
  *                                 example: "pending"
+ *                               programStatus:
+ *                                 type: string
+ *                                 enum: [ongoing, completed]
+ *                                 description: 프로그램 상태 (ongoing=진행중, completed=종료)
+ *                                 example: "ongoing"
  *                     tmi:
  *                       type: object
  *                       description: TMI 그룹
@@ -873,6 +883,11 @@ router.get("/me/commented-posts", authGuard, userController.getMyCommentedPosts)
  *                                 type: string
  *                                 description: 신청 상태
  *                                 example: "approved"
+ *                               programStatus:
+ *                                 type: string
+ *                                 enum: [ongoing, completed]
+ *                                 description: 프로그램 상태 (ongoing=진행중, completed=종료)
+ *                                 example: "completed"
  *             example:
  *               status: 200
  *               data:
@@ -882,21 +897,25 @@ router.get("/me/commented-posts", authGuard, userController.getMyCommentedPosts)
  *                     - id: "CP:G7C66H69GK"
  *                       name: "15일 동안 음악 일기 쓰기"
  *                       status: "approved"
+ *                       programStatus: "ongoing"
  *                     - id: "CP:ABC123DEF456"
  *                       name: "플래너 작성하기"
  *                       status: "pending"
+ *                       programStatus: "completed"
  *                 gathering:
  *                   label: "월간 소모임"
  *                   items:
  *                     - id: "CP:VYTTZW33IH"
  *                       name: "하루 한조각, 일상 속 퍼즐 찾기"
  *                       status: "approved"
+ *                       programStatus: "ongoing"
  *                 tmi:
  *                   label: "TMI"
  *                   items:
  *                     - id: "CP:I4U3J7TM07"
  *                       name: "TMI 자아탐색"
  *                       status: "pending"
+ *                       programStatus: "completed"
  *       401:
  *         description: 인증 실패
  *         content:


### PR DESCRIPTION
<!--
[PR 컨벤션]
1. 제목예시 ) [FEAT#1] 버튼 컴포넌트 기능 구현
2. 리뷰어 지정, 태그 설정
-->

## 📝 작업 내용

<!-- 이 PR에서 구현한 기능이나 수정한 내용을 간단히 설명해주세요 -->
- 참여중 커뮤니티 조회 api에 programStatus 필드 추가(진행 중/완료 둘 다 표시)
## 🎯 관련 이슈

<!-- 관련 이슈를 연결하고 자동으로 클로즈하려면 아래 키워드 중 하나를 사용하세요 -->
<!-- Closes #123 / Fixes #123 / Resolves #123 -->

Closes #2 

## 🔄 변경사항

<!-- ex)
- FCM 기본 세팅
-->

- user 파일 수정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 커뮤니티에 프로그램 상태 정보 추가: 각 커뮤니티마다 진행 중 또는 완료됨 상태 표시
  * 참여 커뮤니티 목록 개선: 진행 중인 커뮤니티와 완료된 커뮤니티를 모두 조회 가능

* **개선 사항**
  * 커뮤니티 필터링 로직 최적화로 더욱 정확한 데이터 제공

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->