### PR TITLE
[FIX#11] 게시글, 댓글 알림 링크 수정

### DIFF
--- a/be/functions/src/constants/urlConstants.js
+++ b/be/functions/src/constants/urlConstants.js
@@ -1,0 +1,10 @@
+const BASE_URL = "https://youth-it.vercel.app";
+
+const NOTIFICATION_LINKS = {
+  POST: (postId, communityId) => `${BASE_URL}/community/post/${postId}?communityId=${communityId}`,
+  MISSION_POST: (postId) => `${BASE_URL}/community/mission/${postId}`,
+  PROGRAM: (programId) => `${BASE_URL}/programs/${programId}`,
+};
+
+module.exports = { BASE_URL, NOTIFICATION_LINKS };
+

--- a/be/functions/src/services/commentService.js
+++ b/be/functions/src/services/commentService.js
@@ -4,6 +4,7 @@ const fcmHelper = require("../utils/fcmHelper");
 const UserService = require("./userService");
 const {sanitizeContent} = require("../utils/sanitizeHelper");
 const {isAdminUser} = require("../utils/helpers");
+const {NOTIFICATION_LINKS} = require("../constants/urlConstants");
 
 /**
  * Comment Service (비즈니스 로직 계층)
@@ -242,7 +243,7 @@ class CommentService {
 
       if (post.authorId !== userId) {
         const commenterName = author !== "익명" ? author : "사용자";
-        const link = `https://youth-it.vercel.app/community/post/${postId}?communityId=${communityId}`;
+        const link = NOTIFICATION_LINKS.POST(postId, communityId);
         fcmHelper.sendNotification(
           post.authorId,
           "새로운 댓글이 달렸습니다",
@@ -270,7 +271,7 @@ class CommentService {
         // author는 이미 게시글 isPublic에 따라 올바르게 설정됨
         const commenterName = author !== "익명" ? author : "사용자";
         console.log(`대댓글 알림 전송: ${parentComment.userId}에게 답글 알림`);
-        const link = `https://youth-it.vercel.app/community/post/${postId}?communityId=${communityId}`;
+        const link = NOTIFICATION_LINKS.POST(postId, communityId);
         fcmHelper.sendNotification(
           parentComment.userId,
           "새로운 답글이 달렸습니다",
@@ -842,7 +843,7 @@ class CommentService {
                 ? commentPreview.substring(0, CommentService.MAX_NOTIFICATION_TEXT_LENGTH) + "..."
                 : commentPreview;
 
-            const link = `https://youth-it.vercel.app/community/post/${comment.postId}?communityId=${comment.communityId}`;
+            const link = NOTIFICATION_LINKS.POST(comment.postId, comment.communityId);
             fcmHelper
               .sendNotification(
                 comment.userId,

--- a/be/functions/src/services/communityService.js
+++ b/be/functions/src/services/communityService.js
@@ -4,6 +4,7 @@ const fcmHelper = require("../utils/fcmHelper");
 const {sanitizeContent} = require("../utils/sanitizeHelper");
 const fileService = require("./fileService");
 const {isAdminUser} = require("../utils/helpers");
+const {NOTIFICATION_LINKS} = require("../constants/urlConstants");
 
 const PROGRAM_TYPES = {
   ROUTINE: "ROUTINE",
@@ -1962,7 +1963,7 @@ class CommunityService {
               }
             }
 
-            const link = `https://youth-it.vercel.app/community/post/${postId}?communityId=${communityId}`;
+            const link = NOTIFICATION_LINKS.POST(postId, communityId);
             fcmHelper.sendNotification(
               post.authorId,
               "게시글에 좋아요가 달렸습니다",

--- a/be/functions/src/services/missionPostService.js
+++ b/be/functions/src/services/missionPostService.js
@@ -5,6 +5,7 @@ const { getDateKeyByUTC, getTodayByUTC } = require("../utils/helpers");
 const FirestoreService = require("./firestoreService");
 const UserService = require("./userService");
 const fcmHelper = require("../utils/fcmHelper");
+const {NOTIFICATION_LINKS} = require("../constants/urlConstants");
 const {
   parsePageSize,
   sanitizeCursor,
@@ -779,7 +780,7 @@ class MissionPostService {
 
       // 알림 전송 (본인 게시글이 아닌 경우)
       if (post.userId !== userId) {
-        const link = `https://youth-it.vercel.app/community/mission/${postId}`;
+        const link = NOTIFICATION_LINKS.MISSION_POST(postId);
         fcmHelper
           .sendNotification(
             post.userId,
@@ -800,7 +801,7 @@ class MissionPostService {
       if (parentId && parentComment && parentComment.userId !== userId && parentComment.userId !== post.userId) {
         const textOnly = typeof parentComment.content === "string" ? parentComment.content.replace(/<[^>]*>/g, "") : "";
         const previewText = textOnly.length > 10 ? textOnly.substring(0, 10) + "..." : textOnly;
-        const link = `https://youth-it.vercel.app/community/mission/${postId}`;
+        const link = NOTIFICATION_LINKS.MISSION_POST(postId);
 
         fcmHelper
           .sendNotification(
@@ -1432,7 +1433,7 @@ class MissionPostService {
             const likerProfile = await userService.getUserById(userId);
             const likerName = likerProfile?.nickname || "사용자";
 
-            const link = `https://youth-it.vercel.app/community/mission/${postId}`;
+            const link = NOTIFICATION_LINKS.MISSION_POST(postId);
             fcmHelper
               .sendNotification(
                 post.userId,
@@ -1564,7 +1565,7 @@ class MissionPostService {
                 ? commentPreview.substring(0, MissionPostService.MAX_PREVIEW_TEXT_LENGTH) + "..."
                 : commentPreview;
 
-            const link = `https://youth-it.vercel.app/community/mission/${comment.postId}`;
+            const link = NOTIFICATION_LINKS.MISSION_POST(comment.postId);
             fcmHelper
               .sendNotification(
                 comment.userId,

--- a/be/functions/src/services/programService.js
+++ b/be/functions/src/services/programService.js
@@ -20,6 +20,7 @@ const CommunityService = require('./communityService');
 const { db, FieldValue } = require('../config/database');
 const { validateNicknameOrThrow } = require('../utils/nicknameValidator');
 const fcmHelper = require('../utils/fcmHelper');
+const {NOTIFICATION_LINKS} = require('../constants/urlConstants');
 
 // 상수 정의
 const NOTION_VERSION = process.env.NOTION_VERSION || "2025-09-03";
@@ -1163,7 +1164,7 @@ class ProgramService {
             "ANNOUNCEMENT",
             "",
             "",
-            `https://youth-it.vercel.app/programs/${programId}`
+            NOTIFICATION_LINKS.PROGRAM(programId)
           );
           
           console.log(`[ProgramService] 승인 알림 발송 완료 - userId: ${member.userId}, programName: ${programName}`);


### PR DESCRIPTION
<!--
[PR 컨벤션]
1. 제목예시 ) [FEAT#1] 버튼 컴포넌트 기능 구현
2. 리뷰어 지정, 태그 설정
-->

## 📝 작업 내용

<!-- 이 PR에서 구현한 기능이나 수정한 내용을 간단히 설명해주세요 -->
- 커뮤니티, 미션 게시글, 댓글관련 알림 link 버셀 주소 반영
## 🎯 관련 이슈

<!-- 관련 이슈를 연결하고 자동으로 클로즈하려면 아래 키워드 중 하나를 사용하세요 -->
<!-- Closes #123 / Fixes #123 / Resolves #123 -->

Closes #11 

## 🔄 변경사항

<!-- ex)
- FCM 기본 세팅
-->

- 커뮤니티, 코멘트, 미션 포스트 서비스 수정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 댓글, 답글, 댓글 좋아요 알림에 관련 게시물로 바로 이동하는 클릭 가능한 링크가 추가되었습니다.
  * 미션 게시물 관련 알림(댓글·답글·좋아요)에 해당 미션 게시물로 연결되는 링크가 포함됩니다.
  * 프로그램 승인 알림에 프로그램 상세로 이동하는 링크가 포함되어 알림 내비게이션이 개선되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->