### PR TITLE
[FIX#32] 마이페이지에서 게시글과 댓글단글 탭의 카드 크기가 다른 현상 해

### DIFF
--- a/fe/src/components/my-page/PostCard.tsx
+++ b/fe/src/components/my-page/PostCard.tsx
@@ -66,7 +66,7 @@ const PostCard = ({
       {/* 게시글 정보 */}
       <div className="flex h-27 flex-col justify-between gap-1 p-2">
         {/* 제목/태그 */}
-        <Typography font="noto" variant="label2M" className="text-pink-600">
+        <Typography font="noto" variant="label2M" className="truncate text-pink-600">
           {title}
         </Typography>
 


### PR DESCRIPTION
<!--
[PR 컨벤션]
1. 제목예시 ) [FEAT#1] 버튼 컴포넌트 기능 구현
2. 리뷰어 지정, 태그 설정
-->

## 📝 작업 내용

글 내용이 한 줄일 때, 두 줄 이상일 때 카드 크기가 달라서 카드 높이를 통일함.

## 🎯 관련 이슈

<!-- 관련 이슈를 연결하고 자동으로 클로즈하려면 아래 키워드 중 하나를 사용하세요 -->
<!-- Closes #123 / Fixes #123 / Resolves #123 -->

Closes #

## 🔄 변경사항

<!-- ex)
- FCM 기본 세팅
-->

-

## 👀 리뷰 포인트

<!-- 특히 리뷰받고 싶은 부분이나 확인이 필요한 내용을 적어주세요 -->
<!-- ex)
1. 이 훅에서 이 로직에서 코드 중복이 많이 일어나고 있어요. 어떻게 개선하는 게 좋을까요?
2. 이 함수의 이름을 더 직관적으로 바꿀 수 있는 방법이 있을까요?
 -->

1. 전체적으로 코드 리뷰 받고 싶습니다.

<!-- 아래 내용은 선택사항이므로, 있을 때만 적어주시고, 없으면 지우셔도 됩니다. -->

## 📱 스크린샷/영상

<!-- Frontend 변경사항이 있는 경우 Before/After 또는 동작 화면 -->

### Before

<!-- 변경 전 화면 -->

### After

<!-- 변경 후 화면 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 게시물 카드의 높이 설정 방식을 개선했습니다 — 최대 높이 제한에서 고정 높이로 변경되어 레이아웃이 더 일정하게 표시됩니다.
  * 게시물 제목에 줄임표 처리(truncate)를 적용해 길이가 긴 제목이 넘칠 때 깔끔하게 잘립니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->