### PR TITLE
[FIX#34] ios 브라우저에서 스토어 cta 버튼 가려짐 해결

### DIFF
--- a/fe/src/app/(main)/store/[id]/page.tsx
+++ b/fe/src/app/(main)/store/[id]/page.tsx
@@ -482,7 +482,7 @@ const StoreProductDetailPage = () => {
       </div>
 
       {/* 하단 고정 버튼 */}
-      <div className="sticky bottom-0 z-20 bg-transparent p-4">
+      <div className="pb-safe fixed bottom-0 z-20 w-full max-w-[470px] bg-transparent p-4">
         <button
           onClick={() => setIsQuantityPopupOpen(true)}
           className="bg-main-600 hover:bg-main-700 w-full rounded-lg px-4 py-3 text-white transition-colors"


### PR DESCRIPTION
<!--
[PR 컨벤션]
1. 제목예시 ) [FEAT#1] 버튼 컴포넌트 기능 구현
2. 리뷰어 지정, 태그 설정
-->

## 📝 작업 내용

ios 브라우저에서 스토어 cta 버튼 가려짐 해결

## 🎯 관련 이슈

<!-- 관련 이슈를 연결하고 자동으로 클로즈하려면 아래 키워드 중 하나를 사용하세요 -->
<!-- Closes #123 / Fixes #123 / Resolves #123 -->

Closes #

## 🔄 변경사항

<!-- ex)
- FCM 기본 세팅
-->

-

## 👀 리뷰 포인트

<!-- 특히 리뷰받고 싶은 부분이나 확인이 필요한 내용을 적어주세요 -->
<!-- ex)
1. 이 훅에서 이 로직에서 코드 중복이 많이 일어나고 있어요. 어떻게 개선하는 게 좋을까요?
2. 이 함수의 이름을 더 직관적으로 바꿀 수 있는 방법이 있을까요?
 -->

1. 전체적인 코드 리뷰 부탁드립니다.

<!-- 아래 내용은 선택사항이므로, 있을 때만 적어주시고, 없으면 지우셔도 됩니다. -->

## 📱 스크린샷/영상

<!-- Frontend 변경사항이 있는 경우 Before/After 또는 동작 화면 -->

### Before

<!-- 변경 전 화면 -->

### After

<!-- 변경 후 화면 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
  * 스토어 페이지의 하단 액션 버튼이 페이지 스크롤 시에도 항상 화면에 고정되어 표시됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->