### PR TITLE
[FIX#60] 신고 콘텐츠 버그수정

### DIFF
--- a/be/functions/src/services/reportContentService.js
+++ b/be/functions/src/services/reportContentService.js
@@ -750,19 +750,6 @@ async syncReportToNotion(reportData) {
       notionProperties['URL'] = { url: contentUrl };
     }
 
-    // 작성자 상세보기 관계형 필드 추가
-    if (authorNotionPageId) {
-      notionProperties['작성자 상세보기'] = { relation: [{ id: authorNotionPageId }] };
-    } else {
-      notionProperties['작성자 상세보기'] = { relation: [] }; // 페이지를 찾지 못한 경우 빈 배열
-    }
-
-    // 신고자 상세보기 관계형 필드 추가
-    if (reporterNotionPageId) {
-      notionProperties['신고자 상세보기'] = { relation: [{ id: reporterNotionPageId }] };
-    } else {
-      notionProperties['신고자 상세보기'] = { relation: [] }; // 페이지를 찾지 못한 경우 빈 배열
-    }
     
     const notionData = {
       parent: { database_id: this.reportsDatabaseId },


### PR DESCRIPTION
## 📝 작업 내용
기존 노션 신고 페이지 및 콘텐츠 페이지에서 신고자(reporter), 작성자(writer) 필드가 문자열(string) 타입으로 되어 있던 부분을
관계형(Relation) 필드로 수정 하면서 발생한 버그 수정


## 🎯 관련 이슈
Closes #60

## 🔄 변경사항
- 작성자 상세보기, 신고자 상세보기 필드제거







## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * Notion 연동 시 보고서 동기화 과정을 최적화하여 불필요한 추가 관계 정보를 제거했습니다. 이로 인해 보고서 생성 및 저장 프로세스가 더욱 간결해지고 시스템의 안정성이 개선되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->