### PR TITLE
[FEAT#91] 푸시 알림 송신 전 알림 내역 저장

### DIFF
--- a/be/functions/src/services/notificationService.js
+++ b/be/functions/src/services/notificationService.js
@@ -505,6 +505,20 @@ class NotificationService {
           if (marketingFilteredFailedUserIds.length > 0) {
             failedUserIds = failedUserIds.concat(marketingFilteredFailedUserIds);
             console.log(`[알림 필터링] 마케팅 동의하지 않은 사용자 ${marketingFilteredFailedUserIds.length}명을 실패 회원으로 추가`);
+
+            const savePromises = marketingFilteredFailedUserIds.map((userId) =>
+              this.saveNotification(userId, {
+                title,
+                message: content,
+                type: "announcement",
+                postId: "",
+                communityId: "",
+                commentId: ""
+              }).catch((err) => {
+                console.error(`[알림 저장 실패] userId=${userId}:`, err);
+              })
+            );
+            await Promise.all(savePromises);
           }
         } catch (filterError) {
           console.error("[알림 필터링] marketingTermsAgreed 필터링 실패:", filterError.message);


### PR DESCRIPTION
<!--
[PR 컨벤션]
1. 제목예시 ) [FEAT#1] 버튼 컴포넌트 기능 구현
2. 리뷰어 지정, 태그 설정
-->

## 📝 작업 내용

<!-- 이 PR에서 구현한 기능이나 수정한 내용을 간단히 설명해주세요 -->
- 마케팅 푸쉬알림 동의, 일반 푸쉬 알림 동의 여부와 관계없이 알림 내역에서는 볼 수 있도록 로직 변경
## 🎯 관련 이슈

<!-- 관련 이슈를 연결하고 자동으로 클로즈하려면 아래 키워드 중 하나를 사용하세요 -->
<!-- Closes #123 / Fixes #123 / Resolves #123 -->

Closes #91



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 알림 기록 신뢰성 개선: 전송 시도 전에 알림을 미리 저장하여 전송 실패 시에도 기록이 보존됩니다.
  * 마케팅 약관 필터링으로 제외된 사용자의 알림도 정상적으로 기록됩니다.
  * 대량 발송 시 모든 사용자의 알림 기록 프로세스가 개선되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->