### PR TITLE
[FEAT#175] 프로그램 일괄 승인/승인거절/승인대기 추가

### DIFF
--- a/be/functions/src/controllers/programController.js
+++ b/be/functions/src/controllers/programController.js
@@ -367,117 +367,18 @@ class ProgramController {
       
       const result = await programApplicationService.bulkApproveApplications();
 
-      // 프로그램별 통계 포맷팅
       const programStatsText = Object.entries(result.programStats)
         .map(([name, count]) => `${name} (${count}건)`)
         .join(', ');
 
-      const htmlResponse = `
-        <!DOCTYPE html>
-        <html lang="ko">
-        <head>
-          <meta charset="UTF-8">
-          <meta name="viewport" content="width=device-width, initial-scale=1.0">
-          <title>일괄 승인 완료</title>
-          <style>
-            body {
-              font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-              max-width: 600px;
-              margin: 50px auto;
-              padding: 20px;
-              background-color: #f5f5f5;
-            }
-            .container {
-              background: white;
-              border-radius: 8px;
-              padding: 30px;
-              box-shadow: 0 2px 10px rgba(0,0,0,0.1);
-            }
-            h1 {
-              color: ${result.successCount > 0 ? '#22c55e' : '#ef4444'};
-              margin-top: 0;
-            }
-            .stats {
-              background: #f9fafb;
-              padding: 15px;
-              border-radius: 6px;
-              margin: 20px 0;
-            }
-            .stats p {
-              margin: 8px 0;
-              color: #374151;
-            }
-            .success {
-              color: #16a34a;
-              font-weight: bold;
-            }
-            .failed {
-              color: #dc2626;
-              font-weight: bold;
-            }
-            .note {
-              color: #6b7280;
-              font-size: 14px;
-              margin-top: 20px;
-            }
-          </style>
-        </head>
-        <body>
-          <div class="container">
-            <h1>✅ 일괄 승인 ${result.successCount > 0 ? '완료' : '실패'}</h1>
-            <div class="stats">
-              <p>총 <strong>${result.totalCount}건</strong> 처리</p>
-              <p class="success">성공: ${result.successCount}건</p>
-              ${result.failedCount > 0 ? `<p class="failed">실패: ${result.failedCount}건</p>` : ''}
-              ${programStatsText ? `<p>처리된 프로그램: ${programStatsText}</p>` : ''}
-            </div>
-            <p class="note">이 창을 닫으셔도 됩니다.</p>
-          </div>
-        </body>
-        </html>
-      `;
+      const message = `[일괄 승인 완료]\n총 ${result.totalCount}건 처리\n성공: ${result.successCount}건\n실패: ${result.failedCount}건${programStatsText ? `\n처리된 프로그램: ${programStatsText}` : ''}`;
 
-      res.setHeader('Content-Type', 'text/html; charset=utf-8');
-      res.send(htmlResponse);
+      res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+      res.send(message);
 
     } catch (error) {
       console.error('[ProgramController] 일괄 승인 오류:', error.message);
-      
-      const errorHtml = `
-        <!DOCTYPE html>
-        <html lang="ko">
-        <head>
-          <meta charset="UTF-8">
-          <title>오류 발생</title>
-          <style>
-            body {
-              font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-              max-width: 600px;
-              margin: 50px auto;
-              padding: 20px;
-            }
-            .error {
-              background: #fee;
-              border: 1px solid #fcc;
-              padding: 20px;
-              border-radius: 8px;
-            }
-            h1 {
-              color: #c00;
-              margin-top: 0;
-            }
-          </style>
-        </head>
-        <body>
-          <div class="error">
-            <h1>❌ 오류 발생</h1>
-            <p>${error.message || '일괄 승인 처리 중 오류가 발생했습니다.'}</p>
-          </div>
-        </body>
-        </html>
-      `;
-      
-      res.status(500).setHeader('Content-Type', 'text/html; charset=utf-8').send(errorHtml);
+      res.status(500).setHeader('Content-Type', 'text/plain; charset=utf-8').send(`[오류 발생]\n${error.message || '일괄 승인 처리 중 오류가 발생했습니다.'}`);
     }
   }
 
@@ -493,117 +394,18 @@ class ProgramController {
       
       const result = await programApplicationService.bulkRejectApplications();
 
-      // 프로그램별 통계 포맷팅
       const programStatsText = Object.entries(result.programStats)
         .map(([name, count]) => `${name} (${count}건)`)
         .join(', ');
 
-      const htmlResponse = `
-        <!DOCTYPE html>
-        <html lang="ko">
-        <head>
-          <meta charset="UTF-8">
-          <meta name="viewport" content="width=device-width, initial-scale=1.0">
-          <title>일괄 거절 완료</title>
-          <style>
-            body {
-              font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-              max-width: 600px;
-              margin: 50px auto;
-              padding: 20px;
-              background-color: #f5f5f5;
-            }
-            .container {
-              background: white;
-              border-radius: 8px;
-              padding: 30px;
-              box-shadow: 0 2px 10px rgba(0,0,0,0.1);
-            }
-            h1 {
-              color: ${result.successCount > 0 ? '#f59e0b' : '#ef4444'};
-              margin-top: 0;
-            }
-            .stats {
-              background: #f9fafb;
-              padding: 15px;
-              border-radius: 6px;
-              margin: 20px 0;
-            }
-            .stats p {
-              margin: 8px 0;
-              color: #374151;
-            }
-            .success {
-              color: #16a34a;
-              font-weight: bold;
-            }
-            .failed {
-              color: #dc2626;
-              font-weight: bold;
-            }
-            .note {
-              color: #6b7280;
-              font-size: 14px;
-              margin-top: 20px;
-            }
-          </style>
-        </head>
-        <body>
-          <div class="container">
-            <h1>🚫 일괄 거절 ${result.successCount > 0 ? '완료' : '실패'}</h1>
-            <div class="stats">
-              <p>총 <strong>${result.totalCount}건</strong> 처리</p>
-              <p class="success">성공: ${result.successCount}건</p>
-              ${result.failedCount > 0 ? `<p class="failed">실패: ${result.failedCount}건</p>` : ''}
-              ${programStatsText ? `<p>처리된 프로그램: ${programStatsText}</p>` : ''}
-            </div>
-            <p class="note">이 창을 닫으셔도 됩니다.</p>
-          </div>
-        </body>
-        </html>
-      `;
+      const message = `[일괄 거절 완료]\n총 ${result.totalCount}건 처리\n성공: ${result.successCount}건\n실패: ${result.failedCount}건${programStatsText ? `\n처리된 프로그램: ${programStatsText}` : ''}`;
 
-      res.setHeader('Content-Type', 'text/html; charset=utf-8');
-      res.send(htmlResponse);
+      res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+      res.send(message);
 
     } catch (error) {
       console.error('[ProgramController] 일괄 거절 오류:', error.message);
-      
-      const errorHtml = `
-        <!DOCTYPE html>
-        <html lang="ko">
-        <head>
-          <meta charset="UTF-8">
-          <title>오류 발생</title>
-          <style>
-            body {
-              font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-              max-width: 600px;
-              margin: 50px auto;
-              padding: 20px;
-            }
-            .error {
-              background: #fee;
-              border: 1px solid #fcc;
-              padding: 20px;
-              border-radius: 8px;
-            }
-            h1 {
-              color: #c00;
-              margin-top: 0;
-            }
-          </style>
-        </head>
-        <body>
-          <div class="error">
-            <h1>❌ 오류 발생</h1>
-            <p>${error.message || '일괄 거절 처리 중 오류가 발생했습니다.'}</p>
-          </div>
-        </body>
-        </html>
-      `;
-      
-      res.status(500).setHeader('Content-Type', 'text/html; charset=utf-8').send(errorHtml);
+      res.status(500).setHeader('Content-Type', 'text/plain; charset=utf-8').send(`[오류 발생]\n${error.message || '일괄 거절 처리 중 오류가 발생했습니다.'}`);
     }
   }
 
@@ -619,119 +421,21 @@ class ProgramController {
       
       const result = await programApplicationService.bulkPendingApplications();
 
-      // 프로그램별 통계 포맷팅
       const programStatsText = Object.entries(result.programStats)
         .map(([name, count]) => `${name} (${count}건)`)
         .join(', ');
 
-      const htmlResponse = `
-        <!DOCTYPE html>
-        <html lang="ko">
-        <head>
-          <meta charset="UTF-8">
-          <meta name="viewport" content="width=device-width, initial-scale=1.0">
-          <title>일괄 대기 처리 완료</title>
-          <style>
-            body {
-              font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-              max-width: 600px;
-              margin: 50px auto;
-              padding: 20px;
-              background-color: #f5f5f5;
-            }
-            .container {
-              background: white;
-              border-radius: 8px;
-              padding: 30px;
-              box-shadow: 0 2px 10px rgba(0,0,0,0.1);
-            }
-            h1 {
-              color: ${result.successCount > 0 ? '#3b82f6' : '#ef4444'};
-              margin-top: 0;
-            }
-            .stats {
-              background: #f9fafb;
-              padding: 15px;
-              border-radius: 6px;
-              margin: 20px 0;
-            }
-            .stats p {
-              margin: 8px 0;
-              color: #374151;
-            }
-            .success {
-              color: #16a34a;
-              font-weight: bold;
-            }
-            .failed {
-              color: #dc2626;
-              font-weight: bold;
-            }
-            .note {
-              color: #6b7280;
-              font-size: 14px;
-              margin-top: 20px;
-            }
-          </style>
-        </head>
-        <body>
-          <div class="container">
-            <h1>⏸️ 일괄 대기 처리 ${result.successCount > 0 ? '완료' : '실패'}</h1>
-            <div class="stats">
-              <p>총 <strong>${result.totalCount}건</strong> 처리</p>
-              <p class="success">성공: ${result.successCount}건</p>
-              ${result.failedCount > 0 ? `<p class="failed">실패: ${result.failedCount}건</p>` : ''}
-              ${programStatsText ? `<p>처리된 프로그램: ${programStatsText}</p>` : ''}
-            </div>
-            <p class="note">이 창을 닫으셔도 됩니다.</p>
-          </div>
-        </body>
-        </html>
-      `;
+      const message = `[일괄 대기 처리 완료]\n총 ${result.totalCount}건 처리\n성공: ${result.successCount}건\n실패: ${result.failedCount}건${programStatsText ? `\n처리된 프로그램: ${programStatsText}` : ''}`;
 
-      res.setHeader('Content-Type', 'text/html; charset=utf-8');
-      res.send(htmlResponse);
+      res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+      res.send(message);
 
     } catch (error) {
       console.error('[ProgramController] 일괄 대기 처리 오류:', error.message);
-      
-      const errorHtml = `
-        <!DOCTYPE html>
-        <html lang="ko">
-        <head>
-          <meta charset="UTF-8">
-          <title>오류 발생</title>
-          <style>
-            body {
-              font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-              max-width: 600px;
-              margin: 50px auto;
-              padding: 20px;
-            }
-            .error {
-              background: #fee;
-              border: 1px solid #fcc;
-              padding: 20px;
-              border-radius: 8px;
-            }
-            h1 {
-              color: #c00;
-              margin-top: 0;
-            }
-          </style>
-        </head>
-        <body>
-          <div class="error">
-            <h1>❌ 오류 발생</h1>
-            <p>${error.message || '일괄 대기 처리 중 오류가 발생했습니다.'}</p>
-          </div>
-        </body>
-        </html>
-      `;
-      
-      res.status(500).setHeader('Content-Type', 'text/html; charset=utf-8').send(errorHtml);
+      res.status(500).setHeader('Content-Type', 'text/plain; charset=utf-8').send(`[오류 발생]\n${error.message || '일괄 대기 처리 중 오류가 발생했습니다.'}`)
     }
   }
+
 
 }
 

--- a/be/functions/src/routes/programs.js
+++ b/be/functions/src/routes/programs.js
@@ -141,6 +141,122 @@ router.get('/', programController.getPrograms);
  */
 router.get('/search', programController.searchPrograms);
 
+/**
+ * @swagger
+ * /programs/approve:
+ *   get:
+ *     summary: 선택된 신청자 일괄 승인
+ *     description: |
+ *       Notion "프로그램 신청자 관리" DB에서 '선택' 체크박스가 true인 모든 신청자를 일괄 승인합니다.
+ *       
+ *       **처리 과정:**
+ *       1. Notion에서 '선택' 체크박스가 true인 항목 조회
+ *       2. 배치로 승인 처리 (5개씩 + 300ms delay, rate limit 안전)
+ *       3. Firestore member 상태를 'approved'로 변경
+ *       4. Notion '승인여부'를 '승인'으로 변경
+ *       5. FCM 승인 알림 발송
+ *       6. 성공한 항목의 '선택' 체크박스 자동 해제
+ *       
+ *       **주의사항:**
+ *       - 프로그램 구분 없이 선택된 모든 신청자를 처리합니다.
+ *       - 일부 항목이 실패해도 다른 항목은 계속 처리됩니다.
+ *       - 실패한 항목은 '선택' 상태가 유지되어 재시도 가능합니다.
+ *     tags: [Programs]
+ *     responses:
+ *       200:
+ *         description: 일괄 승인 처리 완료
+ *         content:
+ *           text/plain:
+ *             schema:
+ *               type: string
+ *               example: "[일괄 승인 완료]\n총 15건 처리\n성공: 13건\n실패: 2건\n처리된 프로그램: 프로그램A (5건), 프로그램B (8건)"
+ *       500:
+ *         description: 서버 오류
+ *         content:
+ *           text/plain:
+ *             schema:
+ *               type: string
+ *               example: "[오류 발생]\n일괄 승인 처리 중 오류가 발생했습니다."
+ */
+router.get('/approve', programController.bulkApproveApplications);
+
+/**
+ * @swagger
+ * /programs/reject:
+ *   get:
+ *     summary: 선택된 신청자 일괄 거절
+ *     description: |
+ *       Notion "프로그램 신청자 관리" DB에서 '선택' 체크박스가 true인 모든 신청자를 일괄 거절합니다.
+ *       
+ *       **처리 과정:**
+ *       1. Notion에서 '선택' 체크박스가 true인 항목 조회
+ *       2. 배치로 거절 처리 (5개씩 + 300ms delay, rate limit 안전)
+ *       3. Firestore member 상태를 'rejected'로 변경
+ *       4. Notion '승인여부'를 '승인거절'로 변경
+ *       5. FCM 거절 알림 발송
+ *       6. 성공한 항목의 '선택' 체크박스 자동 해제
+ *       
+ *       **주의사항:**
+ *       - 프로그램 구분 없이 선택된 모든 신청자를 처리합니다.
+ *       - 일부 항목이 실패해도 다른 항목은 계속 처리됩니다.
+ *       - 실패한 항목은 '선택' 상태가 유지되어 재시도 가능합니다.
+ *     tags: [Programs]
+ *     responses:
+ *       200:
+ *         description: 일괄 거절 처리 완료
+ *         content:
+ *           text/plain:
+ *             schema:
+ *               type: string
+ *               example: "[일괄 거절 완료]\n총 10건 처리\n성공: 9건\n실패: 1건\n처리된 프로그램: 프로그램C (9건)"
+ *       500:
+ *         description: 서버 오류
+ *         content:
+ *           text/plain:
+ *             schema:
+ *               type: string
+ *               example: "[오류 발생]\n일괄 거절 처리 중 오류가 발생했습니다."
+ */
+router.get('/reject', programController.bulkRejectApplications);
+
+/**
+ * @swagger
+ * /programs/pending:
+ *   get:
+ *     summary: 선택된 신청자 일괄 대기 상태 변경
+ *     description: |
+ *       Notion "프로그램 신청자 관리" DB에서 '선택' 체크박스가 true인 모든 신청자를 승인대기 상태로 변경합니다.
+ *       
+ *       **처리 과정:**
+ *       1. Notion에서 '선택' 체크박스가 true인 항목 조회
+ *       2. 배치로 대기 처리 (5개씩 + 300ms delay, rate limit 안전)
+ *       3. Firestore member 상태를 'pending'으로 변경
+ *       4. Notion '승인여부'를 '승인대기'로 변경
+ *       5. 성공한 항목의 '선택' 체크박스 자동 해제
+ *       
+ *       **주의사항:**
+ *       - 프로그램 구분 없이 선택된 모든 신청자를 처리합니다.
+ *       - 일부 항목이 실패해도 다른 항목은 계속 처리됩니다.
+ *       - 실패한 항목은 '선택' 상태가 유지되어 재시도 가능합니다.
+ *       - 알림은 발송되지 않습니다.
+ *     tags: [Programs]
+ *     responses:
+ *       200:
+ *         description: 일괄 대기 처리 완료
+ *         content:
+ *           text/plain:
+ *             schema:
+ *               type: string
+ *               example: "[일괄 대기 처리 완료]\n총 8건 처리\n성공: 8건\n실패: 0건\n처리된 프로그램: 프로그램D (8건)"
+ *       500:
+ *         description: 서버 오류
+ *         content:
+ *           text/plain:
+ *             schema:
+ *               type: string
+ *               example: "[오류 발생]\n일괄 대기 처리 중 오류가 발생했습니다."
+ */
+router.get('/pending', programController.bulkPendingApplications);
 
 /**
  * @swagger
@@ -458,125 +574,5 @@ router.get('/:programId/applications/:applicationId/approve', programController.
  *               example: "<html><body><h1>서버 오류가 발생했습니다.</h1></body></html>"
  */
 router.get('/:programId/applications/:applicationId/reject', programController.rejectApplication);
-
-/**
- * @swagger
- * /programs/approve:
- *   get:
- *     summary: 선택된 신청자 일괄 승인
- *     description: |
- *       Notion "프로그램 신청자 관리" DB에서 '선택' 체크박스가 true인 모든 신청자를 일괄 승인합니다.
- *       
- *       **처리 과정:**
- *       1. Notion에서 '선택' 체크박스가 true인 항목 조회
- *       2. 각 항목의 프로그램ID와 사용자ID 추출
- *       3. 모든 선택된 신청자를 승인 처리
- *       4. Firestore member 상태를 'approved'로 변경
- *       5. Notion '승인여부'를 '승인'으로 변경
- *       6. FCM 승인 알림 발송
- *       7. 성공한 항목의 '선택' 체크박스 자동 해제
- *       
- *       **주의사항:**
- *       - 프로그램 구분 없이 선택된 모든 신청자를 처리합니다.
- *       - 일부 항목이 실패해도 다른 항목은 계속 처리됩니다.
- *       - 실패한 항목은 '선택' 상태가 유지되어 재시도 가능합니다.
- *     tags: [Programs]
- *     responses:
- *       200:
- *         description: 일괄 승인 처리 완료 (성공/실패 건수 포함)
- *         content:
- *           text/html:
- *             schema:
- *               type: string
- *               example: "<html><body><h1>✅ 일괄 승인 완료</h1><p>총 15건 중 13건 승인 완료, 2건 실패</p><p>처리된 프로그램: 프로그램A (5건), 프로그램B (8건)</p></body></html>"
- *       500:
- *         description: 서버 오류
- *         content:
- *           text/html:
- *             schema:
- *               type: string
- *               example: "<html><body><h1>❌ 오류 발생</h1><p>일괄 승인 처리 중 오류가 발생했습니다.</p></body></html>"
- */
-router.get('/approve', programController.bulkApproveApplications);
-
-/**
- * @swagger
- * /programs/reject:
- *   get:
- *     summary: 선택된 신청자 일괄 거절
- *     description: |
- *       Notion "프로그램 신청자 관리" DB에서 '선택' 체크박스가 true인 모든 신청자를 일괄 거절합니다.
- *       
- *       **처리 과정:**
- *       1. Notion에서 '선택' 체크박스가 true인 항목 조회
- *       2. 각 항목의 프로그램ID와 사용자ID 추출
- *       3. 모든 선택된 신청자를 거절 처리
- *       4. Firestore member 상태를 'rejected'로 변경
- *       5. Notion '승인여부'를 '승인거절'로 변경
- *       6. FCM 거절 알림 발송
- *       7. 성공한 항목의 '선택' 체크박스 자동 해제
- *       
- *       **주의사항:**
- *       - 프로그램 구분 없이 선택된 모든 신청자를 처리합니다.
- *       - 일부 항목이 실패해도 다른 항목은 계속 처리됩니다.
- *       - 실패한 항목은 '선택' 상태가 유지되어 재시도 가능합니다.
- *     tags: [Programs]
- *     responses:
- *       200:
- *         description: 일괄 거절 처리 완료 (성공/실패 건수 포함)
- *         content:
- *           text/html:
- *             schema:
- *               type: string
- *               example: "<html><body><h1>🚫 일괄 거절 완료</h1><p>총 10건 중 9건 거절 완료, 1건 실패</p><p>처리된 프로그램: 프로그램C (9건)</p></body></html>"
- *       500:
- *         description: 서버 오류
- *         content:
- *           text/html:
- *             schema:
- *               type: string
- *               example: "<html><body><h1>❌ 오류 발생</h1><p>일괄 거절 처리 중 오류가 발생했습니다.</p></body></html>"
- */
-router.get('/reject', programController.bulkRejectApplications);
-
-/**
- * @swagger
- * /programs/pending:
- *   get:
- *     summary: 선택된 신청자 일괄 대기 상태 변경
- *     description: |
- *       Notion "프로그램 신청자 관리" DB에서 '선택' 체크박스가 true인 모든 신청자를 승인대기 상태로 변경합니다.
- *       
- *       **처리 과정:**
- *       1. Notion에서 '선택' 체크박스가 true인 항목 조회
- *       2. 각 항목의 프로그램ID와 사용자ID 추출
- *       3. 모든 선택된 신청자를 대기 상태로 변경
- *       4. Firestore member 상태를 'pending'으로 변경
- *       5. Notion '승인여부'를 '승인대기'로 변경
- *       6. 성공한 항목의 '선택' 체크박스 자동 해제
- *       
- *       **주의사항:**
- *       - 프로그램 구분 없이 선택된 모든 신청자를 처리합니다.
- *       - 일부 항목이 실패해도 다른 항목은 계속 처리됩니다.
- *       - 실패한 항목은 '선택' 상태가 유지되어 재시도 가능합니다.
- *       - 알림은 발송되지 않습니다.
- *     tags: [Programs]
- *     responses:
- *       200:
- *         description: 일괄 대기 처리 완료 (성공/실패 건수 포함)
- *         content:
- *           text/html:
- *             schema:
- *               type: string
- *               example: "<html><body><h1>⏸️ 일괄 대기 처리 완료</h1><p>총 8건 중 8건 처리 완료</p><p>처리된 프로그램: 프로그램D (8건)</p></body></html>"
- *       500:
- *         description: 서버 오류
- *         content:
- *           text/html:
- *             schema:
- *               type: string
- *               example: "<html><body><h1>❌ 오류 발생</h1><p>일괄 대기 처리 중 오류가 발생했습니다.</p></body></html>"
- */
-router.get('/pending', programController.bulkPendingApplications);
 
 module.exports = router;

--- a/be/functions/src/services/programApplicationService.js
+++ b/be/functions/src/services/programApplicationService.js
@@ -908,13 +908,28 @@ class ProgramApplicationService {
         };
       }
 
-      const results = await Promise.allSettled(
-        applications.map(app => 
-          this.approveApplication(app.programId, app.userId)
-            .then(() => ({ success: true, pageId: app.pageId, programId: app.programId, programName: app.programName }))
-            .catch(error => ({ success: false, pageId: app.pageId, error: error.message, programId: app.programId, programName: app.programName }))
-        )
-      );
+      // 배치 처리로 rate limit 회피 (5개씩 + 300ms delay)
+      const results = [];
+      const BATCH_SIZE = 5;
+      
+      for (let i = 0; i < applications.length; i += BATCH_SIZE) {
+        const batch = applications.slice(i, i + BATCH_SIZE);
+        
+        const batchResults = await Promise.allSettled(
+          batch.map(app => 
+            this.approveApplication(app.programId, app.userId)
+              .then(() => ({ success: true, pageId: app.pageId, programId: app.programId, programName: app.programName }))
+              .catch(error => ({ success: false, pageId: app.pageId, error: error.message, programId: app.programId, programName: app.programName }))
+          )
+        );
+        
+        results.push(...batchResults);
+        
+        // 다음 배치 전 delay (rate limit 고려)
+        if (i + BATCH_SIZE < applications.length) {
+          await new Promise(resolve => setTimeout(resolve, 300));
+        }
+      }
 
       const successResults = results.filter(r => r.status === 'fulfilled' && r.value.success);
       const failedResults = results.filter(r => r.status === 'rejected' || (r.status === 'fulfilled' && !r.value.success));
@@ -957,13 +972,28 @@ class ProgramApplicationService {
         };
       }
 
-      const results = await Promise.allSettled(
-        applications.map(app => 
-          this.rejectApplication(app.programId, app.userId)
-            .then(() => ({ success: true, pageId: app.pageId, programId: app.programId, programName: app.programName }))
-            .catch(error => ({ success: false, pageId: app.pageId, error: error.message, programId: app.programId, programName: app.programName }))
-        )
-      );
+      // 배치 처리로 rate limit 회피 (5개씩 + 300ms delay)
+      const results = [];
+      const BATCH_SIZE = 5;
+      
+      for (let i = 0; i < applications.length; i += BATCH_SIZE) {
+        const batch = applications.slice(i, i + BATCH_SIZE);
+        
+        const batchResults = await Promise.allSettled(
+          batch.map(app => 
+            this.rejectApplication(app.programId, app.userId)
+              .then(() => ({ success: true, pageId: app.pageId, programId: app.programId, programName: app.programName }))
+              .catch(error => ({ success: false, pageId: app.pageId, error: error.message, programId: app.programId, programName: app.programName }))
+          )
+        );
+        
+        results.push(...batchResults);
+        
+        // 다음 배치 전 delay (rate limit 고려)
+        if (i + BATCH_SIZE < applications.length) {
+          await new Promise(resolve => setTimeout(resolve, 300));
+        }
+      }
 
       const successResults = results.filter(r => r.status === 'fulfilled' && r.value.success);
 
@@ -1005,13 +1035,28 @@ class ProgramApplicationService {
         };
       }
 
-      const results = await Promise.allSettled(
-        applications.map(app => 
-          this.pendingApplication(app.programId, app.userId)
-            .then(() => ({ success: true, pageId: app.pageId, programId: app.programId, programName: app.programName }))
-            .catch(error => ({ success: false, pageId: app.pageId, error: error.message, programId: app.programId, programName: app.programName }))
-        )
-      );
+      // 배치 처리로 rate limit 회피 (5개씩 + 300ms delay)
+      const results = [];
+      const BATCH_SIZE = 5;
+      
+      for (let i = 0; i < applications.length; i += BATCH_SIZE) {
+        const batch = applications.slice(i, i + BATCH_SIZE);
+        
+        const batchResults = await Promise.allSettled(
+          batch.map(app => 
+            this.pendingApplication(app.programId, app.userId)
+              .then(() => ({ success: true, pageId: app.pageId, programId: app.programId, programName: app.programName }))
+              .catch(error => ({ success: false, pageId: app.pageId, error: error.message, programId: app.programId, programName: app.programName }))
+          )
+        );
+        
+        results.push(...batchResults);
+        
+        // 다음 배치 전 delay (rate limit 고려)
+        if (i + BATCH_SIZE < applications.length) {
+          await new Promise(resolve => setTimeout(resolve, 300));
+        }
+      }
 
       const successResults = results.filter(r => r.status === 'fulfilled' && r.value.success);
 


### PR DESCRIPTION
<!--
[PR 컨벤션]
1. 제목예시 ) [FEAT#1] 버튼 컴포넌트 기능 구현
2. 리뷰어 지정, 태그 설정
-->

## 📝 작업 내용

- 프로그램 일괄 승인/승인거절/승인대기 추가
## 🎯 관련 이슈

<!-- 관련 이슈를 연결하고 자동으로 클로즈하려면 아래 키워드 중 하나를 사용하세요 -->
<!-- Closes #123 / Fixes #123 / Resolves #123 -->

Closes #

## 🔄 변경사항

<!-- ex)
- FCM 기본 세팅
-->

-

## 👀 리뷰 포인트

1. 안정화 시, 단일 승인/승인거절/승인대기 삭제 예정

<!-- 아래 내용은 선택사항이므로, 있을 때만 적어주시고, 없으면 지우셔도 됩니다. -->

## 📱 스크린샷/영상

<!-- Frontend 변경사항이 있는 경우 Before/After 또는 동작 화면 -->

### Before

<!-- 변경 전 화면 -->

### After

<!-- 변경 후 화면 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 선택된 여러 지원자를 한 번에 승인·거절·보류로 일괄 처리하는 신규 엔드포인트 추가
  * 각 일괄 작업의 통합 결과(총건수·성공·실패) 및 프로그램별 상세 통계 제공
  * 성공 항목의 Notion 선택 표시 자동 초기화 및 후속 알림 전송
  * 처리 흐름과 응답(성공/오류)에 대한 API 문서(스펙) 추가 및 개선
  * 일괄 처리 중 발생한 오류에 대한 간단한 텍스트 요약 반환 및 로깅 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->