### PR TITLE
[FEAT#201] 게시글 목록 조회시 이미지 개수 필드 추가

### DIFF
--- a/be/functions/src/config/swagger.js
+++ b/be/functions/src/config/swagger.js
@@ -1555,6 +1555,11 @@ const options = {
               description: "첫 번째 썸네일 이미지 URL",
               example: "https://storage.googleapis.com/youthvoice-2025.firebasestorage.app/thumbnails/eVyK7rI0-_PM/qr_x4WtsPDPmozu.png",
             },
+            imageCount: {
+              type: "integer",
+              description: "미디어 이미지 개수",
+              example: 3,
+            },
             channel: {
               type: "string",
               description: "채널명",

--- a/be/functions/src/routes/communities.js
+++ b/be/functions/src/routes/communities.js
@@ -124,6 +124,10 @@ const rewardHandler = require("../middleware/rewardHandler");
  *           nullable: true
  *           description: 첫 번째 썸네일 이미지 URL
  *           example: "https://storage.googleapis.com/youthvoice-2025.firebasestorage.app/thumbnails/user123/image_abc123.jpg"
+ *         imageCount:
+ *           type: integer
+ *           description: 미디어 이미지 개수
+ *           example: 3
  *         createdAt:
  *           type: string
  *           format: date-time
@@ -353,6 +357,7 @@ router.get("/", communityController.getCommunities);
  *                           media: ["files/user123/image_abc123.jpg"]
  *                           thumbnailMedia: ["thumbnails/user123/image_abc123.jpg"]
  *                           thumbnailUrl: "https://storage.googleapis.com/youthvoice-2025.firebasestorage.app/thumbnails/user123/image_abc123.jpg"
+ *                           imageCount: 1
  *                           channel: "TMI 자아탐색"
  *                           category: "string"
  *                           scheduledDate: "2025-10-03T17:15:04.882Z"
@@ -681,6 +686,10 @@ router.post("/:communityId/posts", authGuard, rewardHandler, communityController
  *                           nullable: true
  *                           description: 첫 번째 썸네일 이미지 URL
  *                           example: "https://storage.googleapis.com/youthvoice-2025.firebasestorage.app/thumbnails/user123/image_abc123.jpg"
+ *                         imageCount:
+ *                           type: integer
+ *                           description: 미디어 이미지 개수
+ *                           example: 3
  *                         reportsCount:
  *                           type: integer
  *                           description: 신고 횟수

--- a/be/functions/src/services/communityService.js
+++ b/be/functions/src/services/communityService.js
@@ -958,6 +958,9 @@ class CommunityService {
         }
         
         processed.isPublic = resolveIsPublic(post);
+        
+        // imageCount 추가 (media 배열의 길이)
+        processed.imageCount = Array.isArray(post.media) ? post.media.length : 0;
 
         return processed;
       };
@@ -1071,6 +1074,9 @@ class CommunityService {
           blurHash: null,
         };
       }
+      
+      // imageCount 추가 (media 배열의 길이)
+      processedPost.imageCount = Array.isArray(post.media) ? post.media.length : 0;
       
       delete processedPost.content;
       delete processedPost.media;

--- a/be/functions/src/services/userService.js
+++ b/be/functions/src/services/userService.js
@@ -1135,6 +1135,9 @@ class UserService {
         };
       }
       
+      // imageCount 추가 (media 배열의 길이, media 삭제 전에 계산)
+      processedPost.imageCount = Array.isArray(post.media) ? post.media.length : 0;
+      
       delete processedPost.content;
       delete processedPost.media;
       delete processedPost.communityId;


### PR DESCRIPTION
<!--
[PR 컨벤션]
1. 제목예시 ) [FEAT#1] 버튼 컴포넌트 기능 구현
2. 리뷰어 지정, 태그 설정
-->

## 📝 작업 내용

<!-- 이 PR에서 구현한 기능이나 수정한 내용을 간단히 설명해주세요 -->
- imageCount 필드 추가
## 🎯 관련 이슈

<!-- 관련 이슈를 연결하고 자동으로 클로즈하려면 아래 키워드 중 하나를 사용하세요 -->
<!-- Closes #123 / Fixes #123 / Resolves #123 -->

Closes #201 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 커뮤니티 게시물에 미디어 이미지 개수 필드를 추가했습니다. 이제 각 게시물에서 포함된 이미지의 개수를 확인할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->