### PR TITLE
[FIX#213] 타임스탬프-갤러리 선택시, 안드로이드도 사진촬영/갤러리선택 가능하도록

### DIFF
--- a/fe/src/components/shared/text-editor/index.tsx
+++ b/fe/src/components/shared/text-editor/index.tsx
@@ -38,7 +38,7 @@ import type {
 } from "@/types/shared/text-editor";
 import { cn } from "@/utils/shared/cn";
 import { debug } from "@/utils/shared/debugger";
-import { getCameraCaptureValue, isIOSDevice } from "@/utils/shared/device";
+import { isIOSDevice } from "@/utils/shared/device";
 import {
   rgbToHex,
   isElementEmpty,
@@ -2128,37 +2128,12 @@ const TextEditor = ({
         aria-label="파일 업로드"
       />
       <input
-        ref={timestampPhoto.timestampCameraInputRef}
-        type="file"
-        accept={ACCEPT_IMAGE_EXTENSIONS}
-        capture={getCameraCaptureValue()}
-        className="hidden"
-        onChange={timestampPhoto.handleTimestampCameraCapture}
-        aria-label="카메라로 사진 촬영"
-        {...(typeof window !== "undefined" && isIOSDevice()
-          ? {
-              // iOS Safari에서는 capture 속성으로 인한 문제를 방지하기 위해 추가 속성
-              style: {
-                WebkitAppearance: "none",
-                position: "fixed",
-                top: "0",
-                left: "0",
-                width: "1px",
-                height: "1px",
-                opacity: "0",
-                pointerEvents: "none",
-              },
-            }
-          : {})}
-      />
-      <input
         ref={timestampPhoto.timestampGalleryInputRef}
         type="file"
         accept={ACCEPT_IMAGE_EXTENSIONS}
-        capture={getCameraCaptureValue()}
         className="hidden"
         onChange={timestampPhoto.handleTimestampLocalGallerySelect}
-        aria-label="타임스탬프 사진 촬영 또는 갤러리 선택"
+        aria-label="사진 촬영 또는 갤러리에서 선택"
         {...(typeof window !== "undefined" && isIOSDevice()
           ? {
               // iOS Safari에서는 capture 속성으로 인한 문제를 방지하기 위해 추가 속성

--- a/fe/src/components/shared/timestamp-menu/index.tsx
+++ b/fe/src/components/shared/timestamp-menu/index.tsx
@@ -14,6 +14,7 @@ interface TimestampMenuProps {
 /**
  * @description 타임스탬프 메뉴 컴포넌트
  * 갤러리 선택 버튼으로 사진 촬영과 로컬 갤러리 선택을 모두 처리합니다.
+ * iOS와 안드로이드 모두에서 capture 속성이 제거되어 사용자가 직접 선택할 수 있습니다.
  */
 export const TimestampMenu = forwardRef<HTMLDivElement, TimestampMenuProps>(
   ({ isOpen, position, onLocalGalleryClick, onUsitGalleryClick }, ref) => {
@@ -24,7 +25,7 @@ export const TimestampMenu = forwardRef<HTMLDivElement, TimestampMenuProps>(
     return createPortal(
       <div
         ref={ref}
-        className="fixed z-[9999] w-40 overflow-hidden rounded border border-gray-300 bg-white shadow-sm"
+        className="fixed z-[9999] w-48 overflow-hidden rounded border border-gray-300 bg-white shadow-sm"
         style={{
           top: `${position.top}px`,
           left: `${position.left}px`,
@@ -34,7 +35,7 @@ export const TimestampMenu = forwardRef<HTMLDivElement, TimestampMenuProps>(
           type="button"
           className="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-gray-50"
           onClick={onLocalGalleryClick}
-          aria-label="사진 촬영 또는 갤러리 선택"
+          aria-label="갤러리에서 사진 선택"
         >
           <span className="text-sm">갤러리 선택</span>
         </button>

--- a/fe/src/hooks/shared/useTimestampPhoto.ts
+++ b/fe/src/hooks/shared/useTimestampPhoto.ts
@@ -6,15 +6,10 @@ import {
   type ChangeEvent,
 } from "react";
 import type { RefObject } from "react";
-import { FILE_UPLOAD_MESSAGES } from "@/constants/shared/_photo-storage";
 import useToggle from "@/hooks/shared/useToggle";
 import type { ColorPickerPosition } from "@/types/shared/text-editor";
 import { debug } from "@/utils/shared/debugger";
-import {
-  getCameraErrorMessage,
-  getCameraPermissionStatus,
-  isCameraAPISupported,
-} from "@/utils/shared/device";
+import { getCameraErrorMessage } from "@/utils/shared/device";
 import {
   addTimestampToImage,
   getTimestampErrorMessage,
@@ -46,18 +41,13 @@ interface UseTimestampPhotoReturn {
 
   // Refs
   timestampButtonRef: RefObject<HTMLButtonElement | null>;
-  timestampCameraInputRef: RefObject<HTMLInputElement | null>;
   timestampGalleryInputRef: RefObject<HTMLInputElement | null>;
   timestampMenuRef: RefObject<HTMLDivElement | null>;
 
   // 핸들러
   handleTimestampMenuToggle: () => void;
-  handleTimestampCameraClick: () => void;
   handleTimestampLocalGalleryClick: () => void;
   handleTimestampGalleryClick: () => void;
-  handleTimestampCameraCapture: (
-    event: ChangeEvent<HTMLInputElement>
-  ) => Promise<void>;
   handleTimestampLocalGallerySelect: (
     event: ChangeEvent<HTMLInputElement>
   ) => Promise<void>;
@@ -110,7 +100,6 @@ export const useTimestampPhoto = ({
 
   // Refs
   const timestampButtonRef = useRef<HTMLButtonElement>(null);
-  const timestampCameraInputRef = useRef<HTMLInputElement>(null);
   const timestampGalleryInputRef = useRef<HTMLInputElement>(null);
   const timestampMenuRef = useRef<HTMLDivElement>(null);
 
@@ -218,65 +207,6 @@ export const useTimestampPhoto = ({
   }, [showTimestampMenu, updateTimestampMenuPosition]);
 
   /**
-   * 타임스탬프 사진 촬영
-   * - 카메라 API 지원 확인
-   * - 카메라 권한 상태 확인 (가능한 경우)
-   * - 카메라 input 클릭
-   */
-  const handleTimestampCameraClick = useCallback(async () => {
-    setShowTimestampMenu(false);
-
-    try {
-      debug.log("카메라 촬영 버튼 클릭");
-
-      // 카메라 API 지원 확인
-      if (!isCameraAPISupported()) {
-        debug.warn("카메라 API 미지원");
-        showCameraError(FILE_UPLOAD_MESSAGES.CAMERA_NOT_SUPPORTED);
-        return;
-      }
-
-      // 카메라 권한 상태 확인 (가능한 경우)
-      try {
-        const permissionStatus = await getCameraPermissionStatus();
-        if (permissionStatus === "denied") {
-          debug.warn("카메라 권한 거부됨");
-          const errorMessage = getCameraErrorMessage();
-          showCameraError(errorMessage);
-          return;
-        }
-        // "prompt" 상태는 사용자가 직접 권한을 허용할 수 있도록 진행
-        // "granted" 상태는 바로 진행
-        if (permissionStatus === "granted") {
-          debug.log("카메라 권한 허용됨");
-        } else if (permissionStatus === "prompt") {
-          debug.log("카메라 권한 확인 대기 중");
-        }
-      } catch (permissionError) {
-        // Permissions API 미지원 또는 에러 발생 시에도 진행
-        // (일부 브라우저에서는 Permissions API를 지원하지 않을 수 있음)
-        debug.warn("카메라 권한 확인 실패, 계속 진행:", permissionError);
-      }
-
-      // 카메라 input 클릭
-      if (!timestampCameraInputRef.current) {
-        debug.error("카메라 input ref가 없습니다");
-        showCameraError(
-          "카메라를 시작할 수 없습니다. 페이지를 새로고침한 후 다시 시도해주세요."
-        );
-        return;
-      }
-
-      debug.log("카메라 input 클릭");
-      timestampCameraInputRef.current.click();
-    } catch (error) {
-      debug.error("카메라 접근 준비 실패:", error);
-      const errorMessage = getCameraErrorMessage(error);
-      showCameraError(errorMessage);
-    }
-  }, [showCameraError]);
-
-  /**
    * 타임스탬프 로컬 갤러리 선택
    */
   const handleTimestampLocalGalleryClick = useCallback(() => {
@@ -295,112 +225,6 @@ export const useTimestampPhoto = ({
       updateTimestampGalleryPosition();
     });
   }, [updateTimestampGalleryPosition]);
-
-  /**
-   * 타임스탬프 사진 촬영 후 처리
-   */
-  const handleTimestampCameraCapture = useCallback(
-    async (event: ChangeEvent<HTMLInputElement>) => {
-      const file = event.target.files?.[0];
-      if (!file) {
-        // 파일이 선택되지 않은 경우 (사용자가 취소한 경우)
-        debug.log("카메라 촬영 취소됨");
-        return;
-      }
-
-      // input 초기화 (에러 발생 시에도 정리하기 위해 먼저 실행)
-      event.target.value = "";
-
-      let timestampedBlob: Blob | null = null;
-      let blobUrl: string | null = null;
-
-      try {
-        // 파일 검증
-        const validationError = validateImageFile(file);
-        if (validationError) {
-          showCameraError(validationError);
-          return;
-        }
-
-        debug.log("카메라 촬영 파일 처리 시작:", {
-          name: file.name,
-          size: file.size,
-          type: file.type,
-        });
-
-        // 타임스탬프를 적용한 이미지 생성
-        try {
-          timestampedBlob = await addTimestampToImage(file);
-        } catch (timestampError) {
-          debug.error("타임스탬프 추가 실패:", timestampError);
-          showCameraError(getTimestampErrorMessage(timestampError));
-          return;
-        }
-
-        // IndexedDB에 저장 (타임스탬프 적용된 이미지를 File로 변환하여 전달)
-        if (onTimestampPhotoCapture && timestampedBlob) {
-          try {
-            const timestampedFile = new File(
-              [timestampedBlob],
-              "timestamp.jpg",
-              {
-                type: "image/jpeg",
-              }
-            );
-            await onTimestampPhotoCapture(timestampedFile);
-          } catch (storageError) {
-            debug.error("IndexedDB 저장 실패:", storageError);
-            // 저장 실패해도 미리보기는 표시 (사용자가 업로드할 수 있도록)
-            // 에러는 로그만 남기고 계속 진행
-          }
-        }
-
-        // Blob URL 생성
-        try {
-          blobUrl = URL.createObjectURL(timestampedBlob);
-        } catch (urlError) {
-          debug.error("Blob URL 생성 실패:", urlError);
-          // Blob URL 생성 실패 시 메모리 부족 가능성
-          showCameraError(
-            "이미지를 표시할 수 없습니다. 메모리가 부족할 수 있습니다. 브라우저를 새로고침한 후 다시 시도해주세요."
-          );
-          return;
-        }
-
-        // 타임스탬프가 적용된 이미지를 미리보기에 표시
-        setTimestampPreviewImage(timestampedBlob);
-        setTimestampPreviewUrl(blobUrl);
-        setShowTimestampPreview(true);
-
-        debug.log("카메라 촬영 처리 완료");
-      } catch (error) {
-        debug.error("타임스탬프 사진 촬영 실패:", error);
-
-        // 생성된 리소스 정리
-        if (blobUrl) {
-          URL.revokeObjectURL(blobUrl);
-        }
-
-        // 에러 타입에 따른 구체적인 메시지
-        let errorMessage = getCameraErrorMessage(error);
-
-        // 메모리 관련 에러는 별도 처리
-        if (error instanceof Error) {
-          const errorMessageLower = error.message.toLowerCase();
-          if (
-            errorMessageLower.includes("quota") ||
-            errorMessageLower.includes("memory")
-          ) {
-            errorMessage =
-              "메모리가 부족합니다. 다른 이미지를 삭제한 후 다시 시도해주세요.";
-          }
-        }
-
-        showCameraError(errorMessage);
-      }
-    },
-    [onTimestampPhotoCapture, showCameraError]
-  );
 
   /**
    * 타임스탬프 로컬 갤러리 선택 후 처리
@@ -712,16 +536,13 @@ export const useTimestampPhoto = ({
 
     // Refs
     timestampButtonRef,
-    timestampCameraInputRef,
     timestampGalleryInputRef,
     timestampMenuRef,
 
     // 핸들러
     handleTimestampMenuToggle,
-    handleTimestampCameraClick,
     handleTimestampLocalGalleryClick,
     handleTimestampGalleryClick,
-    handleTimestampCameraCapture,
     handleTimestampLocalGallerySelect,
     handleTimestampUpload,
     handleTimestampCancel,


### PR DESCRIPTION
<!--
[PR 컨벤션]
1. 제목예시 ) [FEAT#1] 버튼 컴포넌트 기능 구현
2. 리뷰어 지정, 태그 설정
-->

## 📝 작업 내용

<!-- 이 PR에서 구현한 기능이나 수정한 내용을 간단히 설명해주세요 -->

## 🎯 관련 이슈

<!-- 관련 이슈를 연결하고 자동으로 클로즈하려면 아래 키워드 중 하나를 사용하세요 -->
<!-- Closes #123 / Fixes #123 / Resolves #123 -->

Closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 모바일 기기에서 강제 카메라 촬영 기능 제거 - 사용자가 갤러리에서 사진을 선택할 수 있도록 변경
  
* **UI 개선**
  * 타임스탬프 메뉴 너비 확대로 더 나은 가시성 제공

* **접근성 개선**
  * 메뉴 버튼 레이블 업데이트로 사진 선택 옵션 명확화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->