### PR TITLE
[FIX#222] 안드로이드만 타임스탬프 촬영 버튼 표시

### DIFF
--- a/fe/src/components/shared/text-editor/index.tsx
+++ b/fe/src/components/shared/text-editor/index.tsx
@@ -1697,6 +1697,7 @@ const TextEditor = ({
           position={timestampPhoto.timestampMenuPosition}
           onLocalGalleryClick={timestampPhoto.handleTimestampLocalGalleryClick}
           onUsitGalleryClick={timestampPhoto.handleTimestampGalleryClick}
+          onCameraClick={timestampPhoto.handleTimestampCameraClick}
         />
 
         {/* Timestamp gallery */}
@@ -2128,12 +2129,36 @@ const TextEditor = ({
         aria-label="파일 업로드"
       />
       <input
+        ref={timestampPhoto.timestampCameraInputRef}
+        type="file"
+        accept={ACCEPT_IMAGE_EXTENSIONS}
+        capture="environment"
+        className="hidden"
+        onChange={timestampPhoto.handleTimestampCameraCapture}
+        aria-label="카메라로 사진 촬영"
+        {...(typeof window !== "undefined" && isIOSDevice()
+          ? {
+              // iOS Safari에서는 capture 속성으로 인한 문제를 방지하기 위해 추가 속성
+              style: {
+                WebkitAppearance: "none",
+                position: "fixed",
+                top: "0",
+                left: "0",
+                width: "1px",
+                height: "1px",
+                opacity: "0",
+                pointerEvents: "none",
+              },
+            }
+          : {})}
+      />
+      <input
         ref={timestampPhoto.timestampGalleryInputRef}
         type="file"
         accept={ACCEPT_IMAGE_EXTENSIONS}
         className="hidden"
         onChange={timestampPhoto.handleTimestampLocalGallerySelect}
-        aria-label="사진 촬영 또는 갤러리에서 선택"
+        aria-label="갤러리에서 사진 선택"
         {...(typeof window !== "undefined" && isIOSDevice()
           ? {
               // iOS Safari에서는 capture 속성으로 인한 문제를 방지하기 위해 추가 속성

--- a/fe/src/components/shared/timestamp-menu/index.tsx
+++ b/fe/src/components/shared/timestamp-menu/index.tsx
@@ -3,22 +3,35 @@
 import { forwardRef } from "react";
 import { createPortal } from "react-dom";
 import { useMounted } from "@/hooks/shared/useMounted";
+import { isAndroidDevice } from "@/utils/shared/device";
 
 interface TimestampMenuProps {
   isOpen: boolean;
   position: { top: number; left: number };
   onLocalGalleryClick: () => void;
   onUsitGalleryClick: () => void;
+  onCameraClick?: () => void;
 }
 
 /**
  * @description 타임스탬프 메뉴 컴포넌트
- * 갤러리 선택 버튼으로 사진 촬영과 로컬 갤러리 선택을 모두 처리합니다.
- * iOS와 안드로이드 모두에서 capture 속성이 제거되어 사용자가 직접 선택할 수 있습니다.
+ * 플랫폼별로 최적화된 사진 선택 방식을 제공합니다.
+ * - 안드로이드: 사진 촬영과 갤러리 선택을 명확히 구분하여 제공
+ * - iOS: 시스템 기본 선택지를 활용
  */
 export const TimestampMenu = forwardRef<HTMLDivElement, TimestampMenuProps>(
-  ({ isOpen, position, onLocalGalleryClick, onUsitGalleryClick }, ref) => {
+  (
+    {
+      isOpen,
+      position,
+      onLocalGalleryClick,
+      onUsitGalleryClick,
+      onCameraClick,
+    },
+    ref
+  ) => {
     const isMounted = useMounted();
+    const isAndroid = isAndroidDevice();
 
     if (!isOpen || !isMounted) return null;
 
@@ -31,6 +44,16 @@ export const TimestampMenu = forwardRef<HTMLDivElement, TimestampMenuProps>(
           left: `${position.left}px`,
         }}
       >
+        {isAndroid && onCameraClick && (
+          <button
+            type="button"
+            className="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-gray-50"
+            onClick={onCameraClick}
+            aria-label="사진 촬영"
+          >
+            <span className="text-sm">사진 촬영</span>
+          </button>
+        )}
         <button
           type="button"
           className="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-gray-50"

--- a/fe/src/utils/shared/device.ts
+++ b/fe/src/utils/shared/device.ts
@@ -208,15 +208,15 @@ export const getCameraCaptureValue = (): "environment" | "user" | undefined => {
     return undefined; // capture 속성 제거하여 기본 카메라 앱 사용
   }
 
-  // Android Chrome - 사용자가 선택할 수 있도록 capture 속성 제거
-  // iOS처럼 카메라/갤러리 선택지를 제공하여 UX 일관성 확보
+  // Android Chrome - capture 속성 유지하여 카메라 우선 실행
+  // 안드로이드에서는 capture 속성이 있어야 카메라/갤러리 선택지가 나타남
   if (
     userAgent.includes("Chrome") &&
     userAgent.includes("Mobile") &&
     !isIOS &&
     /Android/i.test(userAgent)
   ) {
-    return undefined; // capture 속성 제거하여 사용자 선택 제공
+    return "environment"; // 후면 카메라 우선
   }
 
   // Firefox Mobile - capture 속성 지원하지만 신뢰성이 낮음
@@ -224,9 +224,9 @@ export const getCameraCaptureValue = (): "environment" | "user" | undefined => {
     return undefined; // capture 속성 제거하여 안정성 확보
   }
 
-  // 그 외 모바일 브라우저 (Android 기반) - 사용자가 선택할 수 있도록 capture 속성 제거
+  // 그 외 모바일 브라우저 (Android 기반) - 후면 카메라 우선
   if (/Android|BlackBerry|IEMobile|Opera Mini/i.test(userAgent) && !isIOS) {
-    return undefined; // capture 속성 제거하여 사용자 선택 제공
+    return "environment"; // 후면 카메라 우선
   }
 
   // 데스크톱 브라우저에서는 capture 속성 불필요


### PR DESCRIPTION
<!--
[PR 컨벤션]
1. 제목예시 ) [FEAT#1] 버튼 컴포넌트 기능 구현
2. 리뷰어 지정, 태그 설정
-->

## 📝 작업 내용

<!-- 이 PR에서 구현한 기능이나 수정한 내용을 간단히 설명해주세요 -->

## 🎯 관련 이슈

<!-- 관련 이슈를 연결하고 자동으로 클로즈하려면 아래 키워드 중 하나를 사용하세요 -->
<!-- Closes #123 / Fixes #123 / Resolves #123 -->

Closes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 타임스탬프 사진에 카메라 캡처 기능 추가
  * Android 기기에서 메뉴에 카메라 촬영 옵션 제공
  * 카메라 권한 확인 및 오류 처리 개선

* **개선사항**
  * iOS Safari 카메라 호환성 최적화
  * 접근성: 갤러리 입력 레이블 업데이트
  * Android에서 후면 카메라 우선 설정

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->