### PR TITLE
[FIX#225] 푸쉬 알림 메시지 수정

### DIFF
--- a/be/functions/src/services/communityService.js
+++ b/be/functions/src/services/communityService.js
@@ -2368,7 +2368,7 @@ class CommunityService {
             fcmHelper.sendNotification(
               post.authorId,
               "게시글에 좋아요가 달렸습니다",
-              `${likerName}님이 "${post.title}"에 좋아요를 눌렀습니다`,
+              `${likerName}님이 회원님의 게시글을 좋아합니다.`,
               "POST_LIKE",
               postId,
               communityId,


### PR DESCRIPTION
<!--
[PR 컨벤션]
1. 제목예시 ) [FEAT#1] 버튼 컴포넌트 기능 구현
2. 리뷰어 지정, 태그 설정
-->

## 📝 작업 내용

<!-- 이 PR에서 구현한 기능이나 수정한 내용을 간단히 설명해주세요 -->
- [x] 게시글/댓글 좋아요, 댓글/답글 작성 푸쉬 알림 메시지 수정
{작성자}님이 댓글을 남겼어요!: {댓글내용 일부}... (전체 40자 제한),
{좋아요회원}님이 회원님의 게시글/댓글}을 좋아합니다

- [x] 답글인 경우 게시글 작성자에게 댓글 알림을 보내지 않도록 수정 (중복 알림 방지)

- [x] 공통 로직 분리
## 🎯 관련 이슈

<!-- 관련 이슈를 연결하고 자동으로 클로즈하려면 아래 키워드 중 하나를 사용하세요 -->
<!-- Closes #123 / Fixes #123 / Resolves #123 -->

Closes #225 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 개선 사항

* **알림 개선**
  * 댓글 알림 최대 길이 확대로 더 상세한 미리보기 제공
  * 댓글 및 대댓글 알림 메시지 형식 일관화 및 HTML 태그 제거
  * 게시글 좋아요 알림 메시지 간소화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->