### PR TITLE
[FEAT#229] rewardHistory reason 필드에 프로그램 유형 필드 반영

### DIFF
--- a/be/functions/src/services/notificationService.js
+++ b/be/functions/src/services/notificationService.js
@@ -98,9 +98,30 @@ class NotificationService {
   }
 
   /**
+   * 템플릿 페이지의 properties에서 프로그램 유형 추출
+   * @param {Object} props - 템플릿 페이지의 properties 객체
+   * @return {string} 프로그램 유형
+   * @private
+   */
+  _extractProgramTypeFromProps(props) {
+    let programType = '';
+    const programTypeField = props[TEMPLATE_FIELDS.PROGRAM_TYPE];
+    if (programTypeField) {
+      if (programTypeField.select && programTypeField.select.name) {
+        programType = programTypeField.select.name;
+      } else if (programTypeField.title && programTypeField.title.length > 0) {
+        programType = programTypeField.title.map(t => t.plain_text).join('').trim();
+      } else {
+        programType = getSelectValue(programTypeField) || getTitleValue(programTypeField) || '';
+      }
+    }
+    return programType;
+  }
+
+  /**
    * 템플릿 페이지 ID로 알림 내용 템플릿 조회
    * @param {string} templatePageId - 템플릿 페이지 ID
-   * @return {Promise<Object|null>} 템플릿 데이터 {content, nadumAmount} 또는 null
+   * @return {Promise<Object|null>} 템플릿 데이터 {content, nadumAmount, programType} 또는 null
    */
   async getNotificationTemplateByPageId(templatePageId) {
     try {
@@ -112,18 +133,7 @@ class NotificationService {
       const props = templatePage.properties;
       const notificationContent = getTextContent(props[TEMPLATE_FIELDS.NOTIFICATION_CONTENT]) || '';
       const nadumAmount = getNumberValue(props[TEMPLATE_FIELDS.NADUM_AMOUNT]) || 0;
-      
-      let programType = '';
-      const programTypeField = props[TEMPLATE_FIELDS.PROGRAM_TYPE];
-      if (programTypeField) {
-        if (programTypeField.select && programTypeField.select.name) {
-          programType = programTypeField.select.name;
-        } else if (programTypeField.title && programTypeField.title.length > 0) {
-          programType = programTypeField.title.map(t => t.plain_text).join('').trim();
-        } else {
-          programType = getSelectValue(programTypeField) || getTitleValue(programTypeField) || '';
-        }
-      }
+      const programType = this._extractProgramTypeFromProps(props);
 
       return {
         content: notificationContent,
@@ -241,19 +251,7 @@ class NotificationService {
       const props = templatePage.properties;
       const notificationContent = getTextContent(props[TEMPLATE_FIELDS.NOTIFICATION_CONTENT]) || '';
       const nadumAmount = getNumberValue(props[TEMPLATE_FIELDS.NADUM_AMOUNT]) || 0;
-      
-      // 프로그램 유형 필드 읽기
-      let programType = '';
-      const programTypeField = props[TEMPLATE_FIELDS.PROGRAM_TYPE];
-      if (programTypeField) {
-        if (programTypeField.select && programTypeField.select.name) {
-          programType = programTypeField.select.name;
-        } else if (programTypeField.title && programTypeField.title.length > 0) {
-          programType = programTypeField.title.map(t => t.plain_text).join('').trim();
-        } else {
-          programType = getSelectValue(programTypeField) || getTitleValue(programTypeField) || '';
-        }
-      }
+      const programType = this._extractProgramTypeFromProps(props);
 
       return {
         content: notificationContent,


### PR DESCRIPTION
<!--
[PR 컨벤션]
1. 제목예시 ) [FEAT#1] 버튼 컴포넌트 기능 구현
2. 리뷰어 지정, 태그 설정
-->

## 📝 작업 내용

<!-- 이 PR에서 구현한 기능이나 수정한 내용을 간단히 설명해주세요 -->
- rewardsHistroy 컬렉션 reason 필드에 관리자 지급일 경우 "추가 나다움 지급/차감" 이 아닌 해당 프로그램 유형으로 저장
-> 나다움 내역에서 정확한 지급/차감 내역을 확인할 수 있음
## 🎯 관련 이슈

<!-- 관련 이슈를 연결하고 자동으로 클로즈하려면 아래 키워드 중 하나를 사용하세요 -->
<!-- Closes #123 / Fixes #123 / Resolves #123 -->

Closes #229 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 및 최적화**
  * 알림에 프로그램 유형(programType)이 포함되어 템플릿 기반 알림의 분류와 전달이 정확해졌습니다.
  * 보상 처리 흐름에서 프로그램 유형을 반영해 보상 사유 표기 및 추적이 향상되었습니다.
  * Notion 연동 필드와 최종 알림 페이로드에 프로그램 유형이 추가되어 데이터 일관성과 가시성이 개선되었습니다.
  * 관련 로그·에러 추적이 강화되어 문제 원인 파악이 수월해졌습니다

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->