### PR TITLE
[FIX#232] 노션 날짜만 입력된 경우 KST 기준으로 시간 보정

### DIFF
--- a/be/functions/src/services/programCommunityService.js
+++ b/be/functions/src/services/programCommunityService.js
@@ -1,6 +1,7 @@
 const CommunityService = require('./communityService');
 const FirestoreService = require('./firestoreService');
 const { FieldValue } = require('../config/database');
+const { normalizeProgramTypeValue } = require('./programService');
 
 /**
  * ProgramCommunityService
@@ -75,8 +76,6 @@ class ProgramCommunityService {
    */
   async createCommunityFromProgram(programId, program) {
     try {
-      const { normalizeProgramTypeValue } = require('./programService');
-      
       const communityData = {
         id: programId,
         name: program?.programName || program?.title || null,
@@ -104,9 +103,6 @@ class ProgramCommunityService {
    */
   async syncCommunityWithNotion(programId, program) {
     try {
-      // programService에서 import한 유틸 함수 사용
-      const { normalizeProgramTypeValue } = require('./programService');
-      
       // Community 전체 데이터 조회
       const community = await this.firestoreService.getDocument('communities', programId);
       if (!community) {


### PR DESCRIPTION
<!--
[PR 컨벤션]
1. 제목예시 ) [FEAT#1] 버튼 컴포넌트 기능 구현
2. 리뷰어 지정, 태그 설정
-->

## 📝 작업 내용

<!-- 이 PR에서 구현한 기능이나 수정한 내용을 간단히 설명해주세요 -->
- 커뮤니티 startDate, endDate 관련 노션 날짜만 입력된 경우 KST 기준으로 시간 보정(00:00:00, 23:59:59)
## 🎯 관련 이슈

<!-- 관련 이슈를 연결하고 자동으로 클로즈하려면 아래 키워드 중 하나를 사용하세요 -->
<!-- Closes #123 / Fixes #123 / Resolves #123 -->

Closes #232 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 커뮤니티 생성 및 동기화 시 날짜 처리 방식이 개선되었습니다. YYYY-MM-DD 형식의 날짜를 한국 표준시(KST) 기준으로 시작/종료 시점(00:00:00 / 23:59:59)을 올바르게 해석하여 기간 경계가 정확해졌습니다.
  * 기존 날짜 정상화는 유지되며, 잘못된 입력은 null로 처리됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->