### PR TITLE
[FEAT#267] 마이페이지-전체활동관리 탭 구현

### DIFF
--- a/fe/src/constants/my-page/_my-page-activity-posts.ts
+++ b/fe/src/constants/my-page/_my-page-activity-posts.ts
@@ -1,0 +1,20 @@
+/**
+ * @description 마이페이지 "전체 활동 관리" 탭 관련 상수
+ */
+
+export const ALL_ACTIVITY_FILTERS = [
+  { id: "all", label: "전체" },
+  { id: "post", label: "게시글" },
+  { id: "commented", label: "댓글단 글" },
+  { id: "liked", label: "좋아요한 글" },
+] as const;
+
+export type AllActivityFilterType = (typeof ALL_ACTIVITY_FILTERS)[number]["id"];
+
+const DEFAULT_ACTIVITY_POSTS_PAGE = 1;
+const DEFAULT_ACTIVITY_POSTS_PAGE_SIZE = 20;
+
+export const DEFAULT_ACTIVITY_POSTS_REQUEST = {
+  page: DEFAULT_ACTIVITY_POSTS_PAGE,
+  size: DEFAULT_ACTIVITY_POSTS_PAGE_SIZE,
+} as const;


### PR DESCRIPTION
<!--
[PR 컨벤션]
1. 제목예시 ) [FEAT#1] 버튼 컴포넌트 기능 구현
2. 리뷰어 지정, 태그 설정
-->

## 📝 작업 내용

<!-- 이 PR에서 구현한 기능이나 수정한 내용을 간단히 설명해주세요 -->

## 🎯 관련 이슈

<!-- 관련 이슈를 연결하고 자동으로 클로즈하려면 아래 키워드 중 하나를 사용하세요 -->
<!-- Closes #123 / Fixes #123 / Resolves #123 -->

Closes #267

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 마이 페이지의 새로운 "모든 활동" 탭에서 전체 게시물, 작성한 게시물, 댓글 남긴 게시물, 좋아요한 게시물을 필터로 나누어 조회할 수 있습니다.
  * 게시물을 클릭하면 해당 커뮤니티로 바로 이동합니다.

* **개선 사항**
  * 탭 네비게이션 UI 개선
  * 루틴이 없을 때 홈으로 안내하는 가이드 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->