### PR TITLE
[FEAT#278] 게시글, 댓글 삭제 내역 추가

### DIFF
--- a/be/functions/src/services/rewardService.js
+++ b/be/functions/src/services/rewardService.js
@@ -833,10 +833,9 @@ class RewardService {
       
       const addSnapshot = await addQuery.get();
       
-      // 2. 차감 내역 조회 (changeType: "deduct" && actionKey: "additional_point" | "store" | "expiration")
+      // 2. 차감 내역 조회 (changeType: "deduct")
       const deductQuery = rewardsHistoryRef
         .where('changeType', '==', 'deduct')
-        .where('actionKey', 'in', ['additional_point', 'store', 'expiration'])
         .orderBy('createdAt', 'desc');
       
       const deductSnapshot = await deductQuery.get();

--- a/fe/src/app/(main)/store/history/nadaum/page.tsx
+++ b/fe/src/app/(main)/store/history/nadaum/page.tsx
@@ -11,6 +11,7 @@ import BottomSheet from "@/components/shared/ui/bottom-sheet";
 import { usersKeys } from "@/constants/generated/query-keys";
 import {
   ACTION_KEY,
+  DELETION_ACTION_KEYS,
   EXPIRATION_DESCRIPTION_TEMPLATE,
   HISTORY_TYPE_LABEL,
   NADAUM_GUIDE_TEXT,
@@ -123,10 +124,17 @@ const Page = () => {
             description = EXPIRATION_DESCRIPTION_TEMPLATE(expirationDate);
           }
         } else if (item.changeType === CHANGE_TYPE.DEDUCT) {
-          // actionKey로 사용/소멸 구분
+          // actionKey로 사용/소멸/삭제 구분
+          const isDeletion = DELETION_ACTION_KEYS.includes(
+            (item.actionKey as string) ?? ""
+          );
+
           if (item.actionKey === ACTION_KEY.EXPIRATION) {
             type = PAGE_FILTER.EXPIRE;
             label = HISTORY_TYPE_LABEL[PAGE_FILTER.EXPIRE];
+          } else if (isDeletion) {
+            type = PAGE_FILTER.USE;
+            label = "게시글/댓글 삭제";
           } else {
             type = PAGE_FILTER.USE;
             label = HISTORY_TYPE_LABEL[PAGE_FILTER.USE];

--- a/fe/src/constants/store/_nadaum-history-constants.ts
+++ b/fe/src/constants/store/_nadaum-history-constants.ts
@@ -41,7 +41,21 @@ export const CHANGE_TYPE = {
  */
 export const ACTION_KEY = {
   EXPIRATION: "expiration",
+  COMMENT_DELETION: "comment",
+  POST_DELETION: "post",
 } as const satisfies Record<string, ActionKey>;
+
+/**
+ * @description 삭제로 표시할 액션 키 목록 (게시글/댓글 삭제 포함)
+ */
+export const DELETION_ACTION_KEYS: readonly string[] = [
+  ACTION_KEY.COMMENT_DELETION,
+  ACTION_KEY.POST_DELETION,
+  "routine_post",
+  "routine_review",
+  "gathering_review_media",
+  "tmi_review",
+] as const;
 
 /**
  * @description 히스토리 타입별 라벨 매핑


### PR DESCRIPTION
<!--
[PR 컨벤션]
1. 제목예시 ) [FEAT#1] 버튼 컴포넌트 기능 구현
2. 리뷰어 지정, 태그 설정
-->

## 📝 작업 내용

<!-- 이 PR에서 구현한 기능이나 수정한 내용을 간단히 설명해주세요 -->
- 게시글, 댓글 삭제 내역 추가
## 🎯 관련 이슈

<!-- 관련 이슈를 연결하고 자동으로 클로즈하려면 아래 키워드 중 하나를 사용하세요 -->
<!-- Closes #123 / Fixes #123 / Resolves #123 -->

Closes #278 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 포인트 이력 조회 범위를 확대하여 더 정확한 포인트 차감 내역 추적 개선
  * 게시글 및 댓글 삭제로 인한 포인트 차감을 명확하게 구분하여 표시
  * 나다움 스토어 이력 화면에서 모든 삭제 관련 포인트 차감 항목이 올바르게 분류되도록 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->