### PR TITLE
[FIX#294] 참여중인 프로그램 조회 시작/종료일 노션 기반 조회로 수정

### DIFF
--- a/be/functions/src/services/userService.js
+++ b/be/functions/src/services/userService.js
@@ -2043,26 +2043,36 @@ class UserService {
           if (programData.startDate) {
             const startDateStr = typeof programData.startDate === 'string' 
               ? programData.startDate 
-              : (programData.startDate instanceof Date ? programData.startDate.toISOString().split('T')[0] : null);
+              : (programData.startDate instanceof Date ? programData.startDate.toISOString() : null);
             if (startDateStr) {
-              startDate = dayjs
-                .tz(startDateStr, "Asia/Seoul")
-                .startOf("day")      // 00:00:00 KST
-                .utc()
-                .toDate();
+              const hasTimeInfo = startDateStr.includes('T');
+              if (hasTimeInfo) {
+                startDate = dayjs(startDateStr).tz("Asia/Seoul").utc().toDate();
+              } else {
+                startDate = dayjs
+                  .tz(startDateStr, "Asia/Seoul")
+                  .startOf("day")      // 00:00:00 KST
+                  .utc()
+                  .toDate();
+              }
             }
           }
           
           if (programData.endDate) {
             const endDateStr = typeof programData.endDate === 'string' 
               ? programData.endDate 
-              : (programData.endDate instanceof Date ? programData.endDate.toISOString().split('T')[0] : null);
+              : (programData.endDate instanceof Date ? programData.endDate.toISOString() : null);
             if (endDateStr) {
-              endDate = dayjs
-                .tz(endDateStr, "Asia/Seoul")
-                .endOf("day")      // 23:59:59 KST
-                .utc()
-                .toDate();
+              const hasTimeInfo = endDateStr.includes('T');
+              if (hasTimeInfo) {
+                endDate = dayjs(endDateStr).tz("Asia/Seoul").utc().toDate();
+              } else {
+                endDate = dayjs
+                  .tz(endDateStr, "Asia/Seoul")
+                  .endOf("day")      // 23:59:59 KST
+                  .utc()
+                  .toDate();
+              }
             }
           }
           
@@ -2121,26 +2131,36 @@ class UserService {
             if (programData.startDate) {
               const startDateStr = typeof programData.startDate === 'string' 
                 ? programData.startDate 
-                : (programData.startDate instanceof Date ? programData.startDate.toISOString().split('T')[0] : null);
+                : (programData.startDate instanceof Date ? programData.startDate.toISOString() : null);
               if (startDateStr) {
-                startDate = dayjs
-                  .tz(startDateStr, "Asia/Seoul")
-                  .startOf("day")      // 00:00:00 KST
-                  .utc()
-                  .toDate();
+                const hasTimeInfo = startDateStr.includes('T');
+                if (hasTimeInfo) {
+                  startDate = dayjs(startDateStr).tz("Asia/Seoul").utc().toDate();
+                } else {
+                  startDate = dayjs
+                    .tz(startDateStr, "Asia/Seoul")
+                    .startOf("day")      // 00:00:00 KST
+                    .utc()
+                    .toDate();
+                }
               }
             }
             
             if (programData.endDate) {
               const endDateStr = typeof programData.endDate === 'string' 
                 ? programData.endDate 
-                : (programData.endDate instanceof Date ? programData.endDate.toISOString().split('T')[0] : null);
+                : (programData.endDate instanceof Date ? programData.endDate.toISOString() : null);
               if (endDateStr) {
-                endDate = dayjs
-                  .tz(endDateStr, "Asia/Seoul")
-                  .endOf("day")      // 23:59:59 KST
-                  .utc()
-                  .toDate();
+                const hasTimeInfo = endDateStr.includes('T');
+                if (hasTimeInfo) {
+                  endDate = dayjs(endDateStr).tz("Asia/Seoul").utc().toDate();
+                } else {
+                  endDate = dayjs
+                    .tz(endDateStr, "Asia/Seoul")
+                    .endOf("day")      // 23:59:59 KST
+                    .utc()
+                    .toDate();
+                }
               }
             }
           }


### PR DESCRIPTION
<!--
[PR 컨벤션]
1. 제목예시 ) [FEAT#1] 버튼 컴포넌트 기능 구현
2. 리뷰어 지정, 태그 설정
-->

## 📝 작업 내용

<!-- 이 PR에서 구현한 기능이나 수정한 내용을 간단히 설명해주세요 -->
- 파베 조회가 아닌 노션기반 조회
## 🎯 관련 이슈

<!-- 관련 이슈를 연결하고 자동으로 클로즈하려면 아래 키워드 중 하나를 사용하세요 -->
<!-- Closes #123 / Fixes #123 / Resolves #123 -->

Closes #294 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정 / 개선**
  * 커뮤니티별 외부(노션) 프로그램 데이터를 병렬로 조회해 날짜 필터링 정확도 향상
  * 노션에서 가져온 시작/종료일을 한국 표준시 → UTC로 변환 적용
  * 노션 원본 날짜와 변환된 날짜를 로깅해 투명성 강화
  * 외부 조회 실패 시 기존 날짜와 로직으로 자동 대체되어 안정성 유지

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->