### PR TITLE
[FEAT#307] 리더사용자변경시 동기화 추가

### DIFF
--- a/be/functions/src/routes/programs.js
+++ b/be/functions/src/routes/programs.js
@@ -575,4 +575,65 @@ router.get('/:programId/applications/:applicationId/approve', programController.
  */
 router.get('/:programId/applications/:applicationId/reject', programController.rejectApplication);
 
+/**
+ * @swagger
+ * /programs/webhooks/leader-change:
+ *   post:
+ *     summary: 노션 웹훅 - 리더 변경
+ *     description: |
+ *       노션 Database Automation에서 리더 변경 시 호출되는 웹훅입니다.
+ *       
+ *       **처리 과정:**
+ *       1. payload에서 프로그램 페이지 ID 추출 → communityId로 변환
+ *       2. rollup에서 리더 userId, nickname 추출
+ *       3. 기존 admin role 멤버 삭제
+ *       4. 새 리더를 admin으로 추가/업데이트
+ *       
+ *       **노션 Automation 설정:**
+ *       - Trigger: "리더 사용자ID" 필드 변경 시
+ *       - Properties: 리더사용자ID (rollup), 리더 사용자 별명 (rollup)
+ *     tags: [Programs]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               source:
+ *                 type: object
+ *                 description: 노션 자동화 메타데이터
+ *               data:
+ *                 type: object
+ *                 properties:
+ *                   id:
+ *                     type: string
+ *                     description: 프로그램 페이지 ID
+ *                   properties:
+ *                     type: object
+ *                     description: 노션 페이지 속성
+ *     responses:
+ *       200:
+ *         description: 리더 업데이트 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: true
+ *                 communityId:
+ *                   type: string
+ *                 newLeaderUserId:
+ *                   type: string
+ *       400:
+ *         description: 잘못된 요청 (리더 정보 없음)
+ *       404:
+ *         description: 커뮤니티를 찾을 수 없음
+ *       500:
+ *         description: 서버 오류
+ */
+router.post('/webhooks/leader-change', programController.handleLeaderChangeWebhook);
+
 module.exports = router;


### PR DESCRIPTION
<!--
[PR 컨벤션]
1. 제목예시 ) [FEAT#1] 버튼 컴포넌트 기능 구현
2. 리뷰어 지정, 태그 설정
-->

## 📝 작업 내용

- 노션에서 리더 사용자 변경 시, firestore에 동기화되도록 로직 추가
- 리더 사용자 변경 시, 커뮤니티 컬렉션 없을 시 프로그램 신청과 동일하게 커뮤니티 컬렉션 추가

## 🎯 관련 이슈

<!-- 관련 이슈를 연결하고 자동으로 클로즈하려면 아래 키워드 중 하나를 사용하세요 -->
<!-- Closes #123 / Fixes #123 / Resolves #123 -->

Closes #307 

## 🔄 변경사항

<!-- ex)
- FCM 기본 세팅
-->

-

## 👀 리뷰 포인트

<!-- 특히 리뷰받고 싶은 부분이나 확인이 필요한 내용을 적어주세요 -->
<!-- ex)
1. 이 훅에서 이 로직에서 코드 중복이 많이 일어나고 있어요. 어떻게 개선하는 게 좋을까요?
2. 이 함수의 이름을 더 직관적으로 바꿀 수 있는 방법이 있을까요?
 -->

1.

<!-- 아래 내용은 선택사항이므로, 있을 때만 적어주시고, 없으면 지우셔도 됩니다. -->

## 📱 스크린샷/영상

<!-- Frontend 변경사항이 있는 경우 Before/After 또는 동작 화면 -->

### Before

<!-- 변경 전 화면 -->

### After

<!-- 변경 후 화면 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 프로그램 커뮤니티의 리더 변경을 처리하는 웹훅 엔드포인트 추가
  * 커뮤니티 리더 정보 업데이트 기능 추가로 리더 교체 시 자동으로 권한 관리

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->