### PR TITLE
[FIX#311] 리더사용자변경시 문제 수정

### DIFF
--- a/be/functions/src/services/programApplicationService.js
+++ b/be/functions/src/services/programApplicationService.js
@@ -1190,11 +1190,19 @@ class ProgramApplicationService {
         // 3. 새 리더가 이미 멤버인지 확인 (중복 DB 호출 제거)
         const existingMember = allMembers.find(m => m.id === newLeaderUserId || m.userId === newLeaderUserId);
         
-        // 4. 기존 admin 삭제 (새 리더와 다른 경우에만)
+        // 4. 기존 admin 처리 (새 리더와 다른 경우에만)
         if (existingAdmin && existingAdmin.userId !== newLeaderUserId) {
-          console.log(`[ProgramApplicationService] 기존 admin 삭제 - userId: ${existingAdmin.userId}`);
           const adminRef = collectionRef.doc(existingAdmin.id);
-          transaction.delete(adminRef);
+          
+          if (existingAdmin.applicantsPageId) {
+            // 기존 신청자면 role만 member로 변경
+            console.log(`[ProgramApplicationService] 기존 admin을 member로 변경 (신청자) - userId: ${existingAdmin.userId}`);
+            transaction.update(adminRef, { role: 'member' });
+          } else {
+            // 신청자가 아니면 삭제
+            console.log(`[ProgramApplicationService] 기존 admin 삭제 - userId: ${existingAdmin.userId}`);
+            transaction.delete(adminRef);
+          }
         }
         
         // 5. 새 리더 처리


### PR DESCRIPTION
<!--
[PR 컨벤션]
1. 제목예시 ) [FEAT#1] 버튼 컴포넌트 기능 구현
2. 리뷰어 지정, 태그 설정
-->

## 📝 작업 내용

- 리더 사용자 수정 시, 기존 사용자 삭제되던 문제 수정

## 🎯 관련 이슈

<!-- 관련 이슈를 연결하고 자동으로 클로즈하려면 아래 키워드 중 하나를 사용하세요 -->
<!-- Closes #123 / Fixes #123 / Resolves #123 -->

Closes #311 

## 🔄 변경사항

<!-- ex)
- FCM 기본 세팅
-->

-

## 👀 리뷰 포인트

<!-- 특히 리뷰받고 싶은 부분이나 확인이 필요한 내용을 적어주세요 -->
<!-- ex)
1. 이 훅에서 이 로직에서 코드 중복이 많이 일어나고 있어요. 어떻게 개선하는 게 좋을까요?
2. 이 함수의 이름을 더 직관적으로 바꿀 수 있는 방법이 있을까요?
 -->

1.

<!-- 아래 내용은 선택사항이므로, 있을 때만 적어주시고, 없으면 지우셔도 됩니다. -->

## 📱 스크린샷/영상

<!-- Frontend 변경사항이 있는 경우 Before/After 또는 동작 화면 -->

### Before

<!-- 변경 전 화면 -->

### After

<!-- 변경 후 화면 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 커뮤니티 리더 업데이트 시 기존 관리자의 처리 방식이 개선되었습니다. 신청자 페이지 정보가 있는 경우 기존 관리자를 삭제하는 대신 멤버로 전환하며, 해당 정보가 없으면 이전 동작을 유지합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->