### PR TITLE
[DESIGN#318] 마이페이지 캘린더-연/월 width 고정, no content 문구 y축 위치 고정

### DIFF
--- a/fe/src/app/(main)/my-page/page.tsx
+++ b/fe/src/app/(main)/my-page/page.tsx
@@ -547,7 +547,7 @@ const Page = () => {
                 <Typography
                   font="noto"
                   variant="body2B"
-                  className="flex items-center text-gray-700"
+                  className="flex w-[90px] items-center justify-center text-gray-700"
                 >
                   {currentDate.year}년 {currentDate.month}월
                 </Typography>
@@ -623,7 +623,7 @@ const Page = () => {
 
               {/* 총 인증 0일 때: 요일 아래(그리드 영역)만 오버레이 + 홈 유도 */}
               {hasNoRoutineCertifications && (
-                <div className="absolute -inset-x-5 -inset-y-2 z-10 flex flex-col items-center justify-center gap-2 bg-white/20 px-6 text-center backdrop-blur-xs">
+                <div className="absolute -inset-x-5 -inset-y-2 z-10 flex flex-col items-center justify-start gap-2 bg-white/20 px-6 pt-20 text-center backdrop-blur-xs">
                   <Typography
                     font="noto"
                     variant="body3M"


### PR DESCRIPTION
<!--
[PR 컨벤션]
1. 제목예시 ) [FEAT#1] 버튼 컴포넌트 기능 구현
2. 리뷰어 지정, 태그 설정
-->

## 📝 작업 내용

<!-- 이 PR에서 구현한 기능이나 수정한 내용을 간단히 설명해주세요 -->

## 🎯 관련 이슈

<!-- 관련 이슈를 연결하고 자동으로 클로즈하려면 아래 키워드 중 하나를 사용하세요 -->
<!-- Closes #123 / Fixes #123 / Resolves #123 -->

Closes #318 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 월 레이블 컨테이너의 레이아웃을 조정하여 연월 표시가 더 명확하고 균형 있게 표시되도록 개선했습니다.
  * 루틴 인증이 없을 때 표시되는 오버레이의 정렬과 여백을 조정하여 사용자 인터페이스의 시각적 표현을 개선했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->