### PR TITLE
[FIX#337] 마이페이지 캘린더에서 게시글 클릭 시 해당 날짜의 communityId로 상세 이동하도록 수정

### DIFF
--- a/fe/src/app/(main)/my-page/page.tsx
+++ b/fe/src/app/(main)/my-page/page.tsx
@@ -597,6 +597,7 @@ const Page = () => {
                     dateKey={day.dateKey}
                     imageUrl={day.imageUrl}
                     postId={day.postId}
+                    communityId={day.communityId}
                     hasPost={day.hasPost}
                     isConsecutive={day.isConsecutive}
                     isCurrentMonth={day.isCurrentMonth}
@@ -611,11 +612,8 @@ const Page = () => {
                         ? undefined
                         : handleCertifyClick
                     }
-                    onPostClick={(postId: string) =>
-                      handlePostClick(
-                        postId,
-                        userData?.currentRoutineCommunityId
-                      )
+                    onPostClick={(postId: string, communityId?: string) =>
+                      handlePostClick(postId, communityId)
                     }
                   />
                 ))}

--- a/fe/src/components/my-page/CalendarDayCell.tsx
+++ b/fe/src/components/my-page/CalendarDayCell.tsx
@@ -12,6 +12,8 @@ interface Props {
   imageUrl?: string;
   /** 게시글 ID */
   postId?: string;
+  /** 커뮤니티 ID (게시글 상세 이동 시 필요) */
+  communityId?: string;
   /** 인증 여부 */
   hasPost: boolean;
   /** 연속 인증 여부 */
@@ -24,8 +26,8 @@ interface Props {
   currentRoutineCommunityId?: string | null;
   /** 인증 버튼 클릭 핸들러 */
   onCertifyClick?: () => void;
-  /** 게시글 클릭 핸들러 */
-  onPostClick?: (postId: string) => void;
+  /** 게시글 클릭 핸들러 (postId, communityId) */
+  onPostClick?: (postId: string, communityId?: string) => void;
 }
 
 /**
@@ -36,6 +38,7 @@ const CalendarDayCell = ({
   dateKey,
   imageUrl,
   postId,
+  communityId,
   hasPost,
   isConsecutive,
   isCurrentMonth,
@@ -46,14 +49,14 @@ const CalendarDayCell = ({
 }: Props) => {
   // 오늘 날짜이고 인증 사진이 없고 currentRoutineCommunityId가 있으면 인증 가능 상태
   const canCertify = isToday && !hasPost && Boolean(currentRoutineCommunityId);
-  // 인증 사진이 있고 postId가 있으면 게시글로 이동 가능
-  const canNavigateToPost = hasPost && imageUrl && postId;
+  // 인증 사진이 있고 postId가 있으면 게시글로 이동 가능 (communityId 있으면 상세 조회 가능)
+  const canNavigateToPost = hasPost && imageUrl && postId && communityId;
 
   const handleClick = () => {
     if (canCertify && onCertifyClick) {
       onCertifyClick();
     } else if (canNavigateToPost && onPostClick && postId) {
-      onPostClick(postId);
+      onPostClick(postId, communityId);
     }
   };
 

--- a/fe/src/utils/my-page/calendar-utils.ts
+++ b/fe/src/utils/my-page/calendar-utils.ts
@@ -8,6 +8,7 @@ export interface CalendarDay {
   dateKey: string;
   imageUrl?: string;
   postId?: string;
+  communityId?: string;
   hasPost: boolean;
   isConsecutive: boolean;
   isCurrentMonth: boolean;
@@ -18,6 +19,7 @@ interface CalendarDayData {
   [dateKey: string]: {
     imageUrl?: string;
     postId?: string;
+    communityId?: string;
   };
 }
 
@@ -114,6 +116,7 @@ export const generateCalendarDays = (
       dateKey,
       imageUrl: dayData?.imageUrl,
       postId: dayData?.postId,
+      communityId: dayData?.communityId,
       hasPost,
       isConsecutive,
       isCurrentMonth: true,


### PR DESCRIPTION
<!--
[PR 컨벤션]
1. 제목예시 ) [FEAT#1] 버튼 컴포넌트 기능 구현
2. 리뷰어 지정, 태그 설정
-->

## 📝 작업 내용

<!-- 이 PR에서 구현한 기능이나 수정한 내용을 간단히 설명해주세요 -->
- 정확한 커뮤니티id기반 게시글 조회
## 🎯 관련 이슈

<!-- 관련 이슈를 연결하고 자동으로 클로즈하려면 아래 키워드 중 하나를 사용하세요 -->
<!-- Closes #123 / Fixes #123 / Resolves #123 -->

Closes #337 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 캘린더 인터페이스에서 게시물 탐색 기능이 개선되었습니다.
  * 특정 커뮤니티에 속한 게시물로의 네비게이션이 더욱 정확하고 명시적으로 처리됩니다.
  * 게시물 클릭 시 관련 커뮤니티 정보가 함께 전달되어 사용자 경험이 향상되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->